### PR TITLE
ROS Paramater Node Names

### DIFF
--- a/clearpath_config/clearpath_config.py
+++ b/clearpath_config/clearpath_config.py
@@ -26,7 +26,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 from clearpath_config.common.types.config import BaseConfig
-from clearpath_config.common.types.serial_number import SerialNumber
 from clearpath_config.common.utils.yaml import read_yaml, write_yaml
 from clearpath_config.system.system import SystemConfig
 from clearpath_config.platform.platform import PlatformConfig
@@ -111,26 +110,18 @@ class ClearpathConfig(BaseConfig):
     def serial_number(self) -> str:
         self.set_config_param(
             self.SERIAL_NUMBER,
-            str(BaseConfig._SERIAL_NUMBER.get_serial()))
-        return BaseConfig._SERIAL_NUMBER.get_serial()
+            str(self.get_serial_number())
+        )
+        return self.get_serial_number()
 
     @serial_number.setter
     def serial_number(self, sn: str) -> None:
-        BaseConfig._SERIAL_NUMBER = SerialNumber(sn)
+        self.set_serial_number(sn)
         self._system.update(serial_number=True)
         self._platform.update(serial_number=True)
         self._links.update(serial_number=True)
         self._mounts.update(serial_number=True)
         self._sensors.update(serial_number=True)
-
-    def get_serial_number(self) -> str:
-        return BaseConfig._SERIAL_NUMBER.get_serial()
-
-    def get_unit_number(self) -> str:
-        return BaseConfig._SERIAL_NUMBER.get_unit()
-
-    def get_model(self) -> str:
-        return BaseConfig._SERIAL_NUMBER.get_model()
 
     @property
     def version(self) -> int:

--- a/clearpath_config/clearpath_config.py
+++ b/clearpath_config/clearpath_config.py
@@ -154,7 +154,7 @@ class ClearpathConfig(BaseConfig):
 
     @system.setter
     def system(self, config: dict) -> None:
-        self._system = SystemConfig(config)
+        self._system.config = config
 
     @property
     def platform(self) -> PlatformConfig:
@@ -165,7 +165,7 @@ class ClearpathConfig(BaseConfig):
 
     @platform.setter
     def platform(self, config: dict) -> None:
-        self._platform = PlatformConfig(config)
+        self._platform.config = config
 
     @property
     def links(self) -> LinksConfig:
@@ -175,8 +175,8 @@ class ClearpathConfig(BaseConfig):
         return self._links
 
     @links.setter
-    def links(self, value: dict) -> None:
-        self._links = LinksConfig(value)
+    def links(self, config: dict) -> None:
+        self._links.config = config
 
     @property
     def mounts(self) -> MountsConfig:
@@ -186,8 +186,8 @@ class ClearpathConfig(BaseConfig):
         return self._mounts
 
     @mounts.setter
-    def mounts(self, value: dict) -> None:
-        self._mounts = MountsConfig(value)
+    def mounts(self, config: dict) -> None:
+        self._sensors.config = config
 
     @property
     def sensors(self) -> SensorConfig:
@@ -197,5 +197,5 @@ class ClearpathConfig(BaseConfig):
         return self._sensors
 
     @sensors.setter
-    def sensors(self, value: dict) -> None:
-        self._sensors = SensorConfig(value)
+    def sensors(self, config: dict) -> None:
+        self._sensors.config = config

--- a/clearpath_config/common/types/config.py
+++ b/clearpath_config/common/types/config.py
@@ -30,7 +30,8 @@ from clearpath_config.common.utils.dictionary import (
     flatten_dict,
     get_from_dict,
     is_in_dict,
-    set_in_dict
+    set_in_dict,
+    unflatten_dict
 )
 from typing import Any
 
@@ -95,6 +96,7 @@ class BaseConfig:
         )
         if self._parent_key is not None and self._parent_key not in value:
             value = {self._parent_key: value}
+        value = unflatten_dict(value)
         for map, prop in flatten_dict(
                 d=self.template, dlim=BaseConfig.DLIM).items():
             keys = map.split(BaseConfig.DLIM)
@@ -110,3 +112,19 @@ class BaseConfig:
     def set_config_param(self, key: str, value: Any) -> None:
         keys = key.split(BaseConfig.DLIM)
         set_in_dict(d=self._config, map=keys, val=value)
+
+    @classmethod
+    def get_serial_number(cls, prefix: bool = False) -> str:
+        return BaseConfig._SERIAL_NUMBER.get_serial(prefix=prefix)
+
+    @classmethod
+    def set_serial_number(cls, sn: str) -> None:
+        BaseConfig._SERIAL_NUMBER = SerialNumber(sn)
+
+    @classmethod
+    def get_unit_number(cls) -> str:
+        return BaseConfig._SERIAL_NUMBER.get_unit()
+
+    @classmethod
+    def get_platform_model(cls) -> str:
+        return BaseConfig._SERIAL_NUMBER.get_model()

--- a/clearpath_config/common/utils/dictionary.py
+++ b/clearpath_config/common/utils/dictionary.py
@@ -105,7 +105,19 @@ def is_in_dict(d, map):
 
 
 def set_in_dict(d, map, val):
-    # get_from_dict(d, map[:-1])[map[-1]] = val
     for key in map[:-1]:
         d = d.setdefault(key, {})
     d[map[-1]] = val
+
+
+def extend_dict(a: dict, b: dict):
+    for key, value in flatten_dict(b).items():
+        keys = key.split(".")
+        set_in_dict(a, keys, value)
+    return a
+
+
+def extend_flat_dict(a: dict, b: dict):
+    for key, value in flatten_dict(b).items():
+        a[key] = value
+    return a

--- a/clearpath_config/common/utils/dictionary.py
+++ b/clearpath_config/common/utils/dictionary.py
@@ -69,6 +69,8 @@ def _unflatten_dict_gen(d: dict, k: str, v: object, dlim: str = '.'):
 def unflatten_dict(d: MutableMapping, parent_key: str = '', dlim: str = '.'):
     _d = {}
     for k, v in d.items():
+        if isinstance(v, dict):
+            v = unflatten_dict(v, parent_key, dlim)
         _d_curr = {}
         _d_next = {}
         keys = k.split(dlim)

--- a/clearpath_config/platform/extras.py
+++ b/clearpath_config/platform/extras.py
@@ -31,8 +31,6 @@ from clearpath_config.common.types.platform import Platform
 from clearpath_config.common.utils.dictionary import (
     flatten_dict,
     flip_dict,
-    get_from_dict,
-    set_in_dict,
     unflatten_dict,
 )
 

--- a/clearpath_config/platform/platform.py
+++ b/clearpath_config/platform/platform.py
@@ -71,7 +71,7 @@ class PlatformConfig(BaseConfig):
         self._config = {}
         self.controller = controller
         self.attachments = attachments
-        self.extras = extras
+        self._extras = ExtrasConfig(extras)
         # Setter Template
         setters = {
             self.KEYS[self.CONTROLLER]: PlatformConfig.controller,
@@ -85,6 +85,8 @@ class PlatformConfig(BaseConfig):
             # Reload attachments
             self.attachments = None
             # TODO: Set PACS Profile
+            # Reload extras
+            self.extras.update(serial_number=serial_number)
 
     @property
     def controller(self) -> str:
@@ -113,7 +115,7 @@ class PlatformConfig(BaseConfig):
     @attachments.setter
     def attachments(self, value: dict) -> None:
         self._attachments = AttachmentsConfigMux(
-            BaseConfig._SERIAL_NUMBER.get_model(), value)
+            self.get_platform_model(), value)
 
     @property
     def extras(self) -> ExtrasConfig:
@@ -126,7 +128,7 @@ class PlatformConfig(BaseConfig):
     @extras.setter
     def extras(self, value: dict | ExtrasConfig) -> None:
         if isinstance(value, dict):
-            self._extras = ExtrasConfig(config=value)
+            self._extras.config = value
         elif isinstance(value, ExtrasConfig):
             self._extras = value
         else:
@@ -138,8 +140,3 @@ class PlatformConfig(BaseConfig):
     def get_controller(self) -> str:
         return self.controller
 
-    def get_unit_number(self) -> str:
-        return BaseConfig._SERIAL_NUMBER.get_unit()
-
-    def get_model(self) -> str:
-        return BaseConfig._SERIAL_NUMBER.get_model()

--- a/clearpath_config/sensors/sensors.py
+++ b/clearpath_config/sensors/sensors.py
@@ -279,7 +279,7 @@ class SensorConfig(BaseConfig):
 
     def update(self, serial_number=False) -> None:
         if serial_number:
-            platform = BaseConfig._SERIAL_NUMBER.get_model()
+            platform = self.get_platform_model()
             index = Platform.INDEX[platform]
             self._camera.set_index_offset(index.camera)
             self._gps.set_index_offset(index.gps)
@@ -922,8 +922,6 @@ class SensorConfig(BaseConfig):
         if not gps and model:
             gps = GlobalPositioningSystem(model)
             gps.set_frame_id(frame_id)
-            gps.set_ip(ip)
-            gps.set_port(port)
             gps.set_urdf_enabled(urdf_enabled)
             gps.set_launch_enabled(launch_enabled)
             gps.set_parent(parent)

--- a/clearpath_config/sensors/sensors.py
+++ b/clearpath_config/sensors/sensors.py
@@ -38,7 +38,9 @@ from clearpath_config.sensors.types.cameras import (
 )
 from clearpath_config.sensors.types.gps import (
     BaseGPS,
-    SwiftNavDuro
+    SwiftNavDuro,
+    Garmin18x,
+    NovatelSmart,
 )
 from clearpath_config.sensors.types.imu import (
     BaseIMU,
@@ -102,9 +104,13 @@ class Camera():
 
 class GlobalPositioningSystem():
     SWIFTNAV_DURO = SwiftNavDuro.SENSOR_MODEL
+    GARMIN_18X = Garmin18x.SENSOR_MODEL
+    NOVATEL_SMART = NovatelSmart.SENSOR_MODEL
 
     MODEL = {
         SWIFTNAV_DURO: SwiftNavDuro,
+        GARMIN_18X: Garmin18x,
+        NOVATEL_SMART: NovatelSmart
     }
 
     @classmethod

--- a/clearpath_config/sensors/sensors.py
+++ b/clearpath_config/sensors/sensors.py
@@ -40,7 +40,8 @@ from clearpath_config.sensors.types.gps import (
     BaseGPS,
     SwiftNavDuro,
     Garmin18x,
-    NovatelSmart,
+    NovatelSmart6,
+    NovatelSmart7,
 )
 from clearpath_config.sensors.types.imu import (
     BaseIMU,
@@ -105,12 +106,14 @@ class Camera():
 class GlobalPositioningSystem():
     SWIFTNAV_DURO = SwiftNavDuro.SENSOR_MODEL
     GARMIN_18X = Garmin18x.SENSOR_MODEL
-    NOVATEL_SMART = NovatelSmart.SENSOR_MODEL
+    NOVATEL_SMART6 = NovatelSmart6.SENSOR_MODEL
+    NOVATEL_SMART7 = NovatelSmart7.SENSOR_MODEL
 
     MODEL = {
         SWIFTNAV_DURO: SwiftNavDuro,
         GARMIN_18X: Garmin18x,
-        NOVATEL_SMART: NovatelSmart
+        NOVATEL_SMART6: NovatelSmart6,
+        NOVATEL_SMART7: NovatelSmart7,
     }
 
     @classmethod

--- a/clearpath_config/sensors/sensors.py
+++ b/clearpath_config/sensors/sensors.py
@@ -904,8 +904,6 @@ class SensorConfig(BaseConfig):
             # By Model and Paramters
             model: str = None,
             frame_id: str = BaseGPS.FRAME_ID,
-            ip: str = BaseGPS.IP_ADDRESS,
-            port: int = BaseGPS.IP_PORT,
             urdf_enabled: bool = BaseSensor.URDF_ENABLED,
             launch_enabled: bool = BaseSensor.LAUNCH_ENABLED,
             parent: str = Accessory.PARENT,

--- a/clearpath_config/sensors/types/gps.py
+++ b/clearpath_config/sensors/types/gps.py
@@ -28,6 +28,7 @@
 from clearpath_config.common.types.accessory import Accessory
 from clearpath_config.common.types.ip import IP
 from clearpath_config.common.types.port import Port
+from clearpath_config.common.types.file import File
 from clearpath_config.common.utils.dictionary import extend_flat_dict
 from clearpath_config.sensors.types.sensor import BaseSensor
 from typing import List
@@ -196,3 +197,146 @@ class SwiftNavDuro(BaseGPS):
 
     def set_port(self, port: int) -> None:
         self.port = port
+
+
+class NMEA(BaseGPS):
+    SENSOR_MODEL = "nmea_gps"
+
+    FRAME_ID = "link"
+    PORT = "/dev/ttyACM0"
+    BAUD = 115200
+
+    class ROS_PARAMETER_KEYS:
+        FRAME_ID = "nmea_navsat_driver.frame_id"
+        PORT = "nmea_navsat_driver.port"
+        BAUD = "nmea_navsat_driver.baud"
+
+    def __init__(
+            self,
+            idx: int = None,
+            name: str = None,
+            topic: str = BaseGPS.TOPIC,
+            frame_id: str = FRAME_ID,
+            port: str = PORT,
+            baud: int = BAUD,
+            urdf_enabled: bool = BaseSensor.URDF_ENABLED,
+            launch_enabled: bool = BaseSensor.LAUNCH_ENABLED,
+            ros_parameters: str = BaseSensor.ROS_PARAMETERS,
+            parent: str = Accessory.PARENT,
+            xyz: List[float] = Accessory.XYZ,
+            rpy: List[float] = Accessory.RPY
+            ) -> None:
+        # Port
+        self.port = port
+        # Baud
+        self.baud = baud
+        # ROS Paramater Template
+        ros_parameters_template = {
+            self.ROS_PARAMETER_KEYS.PORT: NMEA.port,
+            self.ROS_PARAMETER_KEYS.BAUD: NMEA.baud
+        }
+        super().__init__(
+            idx,
+            name,
+            topic,
+            frame_id,
+            urdf_enabled,
+            launch_enabled,
+            ros_parameters,
+            ros_parameters_template,
+            parent,
+            xyz,
+            rpy
+        )
+
+    @property
+    def port(self) -> str:
+        return str(self._port)
+
+    @port.setter
+    def port(self, file: str) -> str:
+        self._port = File(str(file))
+
+    @property
+    def baud(self) -> int:
+        return self._baud
+
+    @baud.setter
+    def baud(self, baud: int) -> None:
+        assert isinstance(baud, int), ("Baud must be of type 'int'.")
+        assert baud >= 0, ("Baud must be positive integer.")
+        self._baud = baud
+
+
+class Garmin18x(NMEA):
+    SENSOR_MODEL = "garmin_18x"
+
+    FRAME_ID = "link"
+    PORT = "/dev/ttyACM0"
+    BAUD = 115200
+
+    def __init__(
+            self,
+            idx: int = None,
+            name: str = None,
+            topic: str = BaseGPS.TOPIC,
+            frame_id: str = FRAME_ID,
+            port: str = PORT,
+            baud: int = BAUD,
+            urdf_enabled: bool = BaseSensor.URDF_ENABLED,
+            launch_enabled: bool = BaseSensor.LAUNCH_ENABLED,
+            ros_parameters: str = BaseSensor.ROS_PARAMETERS,
+            parent: str = Accessory.PARENT,
+            xyz: List[float] = Accessory.XYZ,
+            rpy: List[float] = Accessory.RPY) -> None:
+        super().__init__(
+            idx,
+            name,
+            topic,
+            frame_id,
+            port,
+            baud,
+            urdf_enabled,
+            launch_enabled,
+            ros_parameters,
+            parent,
+            xyz,
+            rpy
+        )
+
+
+class NovatelSmart(NMEA):
+    SENSOR_MODEL = "novatel_smart"
+
+    FRAME_ID = "link"
+    PORT = "/dev/ttyACM0"
+    BAUD = 115200
+
+    def __init__(
+            self,
+            idx: int = None,
+            name: str = None,
+            topic: str = BaseGPS.TOPIC,
+            frame_id: str = FRAME_ID,
+            port: str = PORT,
+            baud: int = BAUD,
+            urdf_enabled: bool = BaseSensor.URDF_ENABLED,
+            launch_enabled: bool = BaseSensor.LAUNCH_ENABLED,
+            ros_parameters: str = BaseSensor.ROS_PARAMETERS,
+            parent: str = Accessory.PARENT,
+            xyz: List[float] = Accessory.XYZ,
+            rpy: List[float] = Accessory.RPY) -> None:
+        super().__init__(
+            idx,
+            name,
+            topic,
+            frame_id,
+            port,
+            baud,
+            urdf_enabled,
+            launch_enabled,
+            ros_parameters,
+            parent,
+            xyz,
+            rpy
+        )

--- a/clearpath_config/sensors/types/gps.py
+++ b/clearpath_config/sensors/types/gps.py
@@ -305,8 +305,45 @@ class Garmin18x(NMEA):
         )
 
 
-class NovatelSmart(NMEA):
-    SENSOR_MODEL = "novatel_smart"
+class NovatelSmart6(NMEA):
+    SENSOR_MODEL = "novatel_smart6"
+
+    FRAME_ID = "link"
+    PORT = "/dev/ttyACM0"
+    BAUD = 115200
+
+    def __init__(
+            self,
+            idx: int = None,
+            name: str = None,
+            topic: str = BaseGPS.TOPIC,
+            frame_id: str = FRAME_ID,
+            port: str = PORT,
+            baud: int = BAUD,
+            urdf_enabled: bool = BaseSensor.URDF_ENABLED,
+            launch_enabled: bool = BaseSensor.LAUNCH_ENABLED,
+            ros_parameters: str = BaseSensor.ROS_PARAMETERS,
+            parent: str = Accessory.PARENT,
+            xyz: List[float] = Accessory.XYZ,
+            rpy: List[float] = Accessory.RPY) -> None:
+        super().__init__(
+            idx,
+            name,
+            topic,
+            frame_id,
+            port,
+            baud,
+            urdf_enabled,
+            launch_enabled,
+            ros_parameters,
+            parent,
+            xyz,
+            rpy
+        )
+
+
+class NovatelSmart7(NMEA):
+    SENSOR_MODEL = "novatel_smart7"
 
     FRAME_ID = "link"
     PORT = "/dev/ttyACM0"

--- a/clearpath_config/sensors/types/gps.py
+++ b/clearpath_config/sensors/types/gps.py
@@ -28,6 +28,7 @@
 from clearpath_config.common.types.accessory import Accessory
 from clearpath_config.common.types.ip import IP
 from clearpath_config.common.types.port import Port
+from clearpath_config.common.utils.dictionary import extend_flat_dict
 from clearpath_config.sensors.types.sensor import BaseSensor
 from typing import List
 
@@ -38,13 +39,9 @@ class BaseGPS(BaseSensor):
     TOPIC = "fix"
 
     FRAME_ID = "link"
-    IP_ADDRESS = "192.168.131.30"
-    IP_PORT = 55555
 
     class ROS_PARAMETER_KEYS:
-        FRAME_ID = "frame_id"
-        IP_ADDRESS = "ip_address"
-        IP_PORT = "ip_port"
+        FRAME_ID = "node_name.frame_id"
 
     def __init__(
             self,
@@ -52,11 +49,10 @@ class BaseGPS(BaseSensor):
             name: str = None,
             topic: str = TOPIC,
             frame_id: str = FRAME_ID,
-            ip: str = IP_ADDRESS,
-            port: int = IP_PORT,
             urdf_enabled: bool = BaseSensor.URDF_ENABLED,
             launch_enabled: bool = BaseSensor.LAUNCH_ENABLED,
             ros_parameters: str = BaseSensor.ROS_PARAMETERS,
+            ros_parameters_template: dict = BaseSensor.ROS_PARAMETERS_TEMPLATE,
             parent: str = Accessory.PARENT,
             xyz: List[float] = Accessory.XYZ,
             rpy: List[float] = Accessory.RPY
@@ -64,12 +60,11 @@ class BaseGPS(BaseSensor):
         # Frame ID
         self.frame_id: str = self.FRAME_ID
         self.set_frame_id(frame_id)
-        # IP Address
-        self.ip: IP = IP(self.IP_ADDRESS)
-        self.set_ip(ip)
-        # IP Port
-        self.port: Port = Port(self.IP_PORT)
-        self.set_port(port)
+        # ROS Parameters Template
+        template = {
+            self.ROS_PARAMETER_KEYS.FRAME_ID: BaseGPS.frame_id,
+        }
+        ros_parameters_template = extend_flat_dict(template, ros_parameters_template)
         super().__init__(
             idx,
             name,
@@ -77,35 +72,11 @@ class BaseGPS(BaseSensor):
             urdf_enabled,
             launch_enabled,
             ros_parameters,
+            ros_parameters_template,
             parent,
             xyz,
             rpy
         )
-        # ROS Parameter Keys
-        pairs = {
-            # Frame ID
-            BaseGPS.ROS_PARAMETER_KEYS.FRAME_ID: (
-                BaseSensor.ROSParameter(
-                    key=BaseGPS.ROS_PARAMETER_KEYS.FRAME_ID,
-                    get=lambda obj: obj.get_frame_id(),
-                    set=lambda obj, val: obj.set_frame_id(val)
-                )
-            ),
-            # IP Address
-            BaseGPS.ROS_PARAMETER_KEYS.IP_ADDRESS: (
-                BaseSensor.ROSParameter(
-                    key=BaseGPS.ROS_PARAMETER_KEYS.IP_ADDRESS,
-                    get=lambda obj: obj.get_ip(),
-                    set=lambda obj, val: obj.set_ip(val))),
-            # IP Port
-            BaseGPS.ROS_PARAMETER_KEYS.IP_PORT: (
-                BaseSensor.ROSParameter(
-                    key=BaseGPS.ROS_PARAMETER_KEYS.IP_PORT,
-                    get=lambda obj: obj.get_port(),
-                    set=lambda obj, val: obj.set_port(val))),
-        }
-        self.ros_parameter_pairs.update(pairs)
-        self.set_ros_parameters(ros_parameters)
 
     @classmethod
     def get_frame_id_from_idx(cls, idx: int) -> str:
@@ -126,38 +97,35 @@ class BaseGPS(BaseSensor):
         super().set_idx(idx)
         # Set Frame ID
         self.set_frame_id(self.get_frame_id_from_idx(idx))
-        # Set IP
-        self.set_ip(self.get_ip_from_idx(idx))
+
+    @property
+    def frame_id(self) -> str:
+        return self._frame_id
+
+    @frame_id.setter
+    def frame_id(self, link: str) -> None:
+        Accessory.assert_valid_link(link)
+        self._frame_id = link
 
     def get_frame_id(self) -> str:
         return self.frame_id
 
     def set_frame_id(self, link: str) -> None:
-        Accessory.assert_valid_link(link)
         self.frame_id = link
-
-    def get_ip(self) -> str:
-        return str(self.ip)
-
-    def set_ip(self, ip: str) -> None:
-        self.ip = IP(ip)
-
-    def get_port(self) -> int:
-        return int(self.port)
-
-    def set_port(self, port: int) -> None:
-        self.port = Port(port)
 
 
 class SwiftNavDuro(BaseGPS):
     SENSOR_MODEL = "swiftnav_duro"
 
     FRAME_ID = "link"
+    IP_ADDRESS = "192.168.131.30"
     IP_PORT = 55555
 
     class ROS_PARAMETER_KEYS:
-        GPS_FRAME = "gps_receiver_frame_id"
-        IMU_FRAME = "imu_frame_id"
+        FRAME_ID = "duro_node.imu_frame_id"
+        GPS_FRAME = "duro_node.gps_receiver_frame_id"
+        IP_ADDRESS = "duro_node.ip_address"
+        IP_PORT = "duro_node.port"
 
     def __init__(
             self,
@@ -165,7 +133,7 @@ class SwiftNavDuro(BaseGPS):
             name: str = None,
             topic: str = BaseGPS.TOPIC,
             frame_id: str = FRAME_ID,
-            ip: str = BaseGPS.IP_ADDRESS,
+            ip: str = IP_ADDRESS,
             port: int = IP_PORT,
             urdf_enabled: bool = BaseSensor.URDF_ENABLED,
             launch_enabled: bool = BaseSensor.LAUNCH_ENABLED,
@@ -174,34 +142,57 @@ class SwiftNavDuro(BaseGPS):
             xyz: List[float] = Accessory.XYZ,
             rpy: List[float] = Accessory.RPY
             ) -> None:
+        # IP Address
+        self.ip: IP = IP(self.IP_ADDRESS)
+        self.set_ip(ip)
+        # IP Port
+        self.port: Port = Port(self.IP_PORT)
+        self.set_port(port)
+        # ROS Parameter Template
+        ros_parameters_template = {
+            self.ROS_PARAMETER_KEYS.IP_ADDRESS: SwiftNavDuro.ip,
+            self.ROS_PARAMETER_KEYS.IP_PORT: SwiftNavDuro.port,
+            self.ROS_PARAMETER_KEYS.FRAME_ID: SwiftNavDuro.frame_id,
+            self.ROS_PARAMETER_KEYS.GPS_FRAME: SwiftNavDuro.frame_id,
+        }
         super().__init__(
             idx,
             name,
             topic,
             frame_id,
-            ip,
-            port,
             urdf_enabled,
             launch_enabled,
             ros_parameters,
+            ros_parameters_template,
             parent,
             xyz,
             rpy
         )
-        # ROS Parameter Keys
-        self.ros_parameter_pairs[
-            BaseGPS.ROS_PARAMETER_KEYS.FRAME_ID].key = (
-                SwiftNavDuro.ROS_PARAMETER_KEYS.GPS_FRAME
-            )
-        pairs = {
-            # Frame ID
-            SwiftNavDuro.ROS_PARAMETER_KEYS.IMU_FRAME: (
-                BaseSensor.ROSParameter(
-                    key=SwiftNavDuro.ROS_PARAMETER_KEYS.IMU_FRAME,
-                    get=lambda obj: obj.get_frame_id(),
-                    set=lambda obj, val: obj.set_frame_id(val)
-                )
-            ),
-        }
-        self.ros_parameter_pairs.update(pairs)
-        self.set_ros_parameters(ros_parameters)
+
+    @property
+    def ip(self) -> str:
+        return str(self._ip)
+
+    @ip.setter
+    def ip(self, ip: str) -> None:
+        self._ip = IP(str(ip))
+
+    def get_ip(self) -> str:
+        return str(self.ip)
+
+    def set_ip(self, ip: str) -> None:
+        self.ip = ip
+
+    @property
+    def port(self) -> int:
+        return int(self._port)
+
+    @port.setter
+    def port(self, port: int) -> None:
+        self._port = Port(int(port))
+
+    def get_port(self) -> int:
+        return int(self.port)
+
+    def set_port(self, port: int) -> None:
+        self.port = port

--- a/clearpath_config/sensors/types/imu.py
+++ b/clearpath_config/sensors/types/imu.py
@@ -27,6 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from clearpath_config.common.types.accessory import Accessory
 from clearpath_config.common.types.file import File
+from clearpath_config.common.utils.dictionary import extend_flat_dict
 from clearpath_config.sensors.types.sensor import BaseSensor
 from typing import List
 
@@ -41,9 +42,9 @@ class BaseIMU(BaseSensor):
     USE_ENU = True
 
     class ROS_PARAMETERS_KEYS:
-        PORT = "port"
-        FRAME_ID = "frame_id"
-        USE_ENU = "use_enu"
+        PORT = "node_name.port"
+        FRAME_ID = "node_name.frame_id"
+        USE_ENU = "node_name.use_enu"
 
     def __init__(
             self,
@@ -55,7 +56,8 @@ class BaseIMU(BaseSensor):
             use_enu: bool = USE_ENU,
             urdf_enabled: bool = BaseSensor.URDF_ENABLED,
             launch_enabled: bool = BaseSensor.LAUNCH_ENABLED,
-            ros_parameters: str = BaseSensor.ROS_PARAMETERS,
+            ros_parameters: dict = BaseSensor.ROS_PARAMETERS,
+            ros_parameters_template: dict = BaseSensor.ROS_PARAMETERS_TEMPLATE,
             parent: str = Accessory.PARENT,
             xyz: List[float] = Accessory.XYZ,
             rpy: List[float] = Accessory.RPY
@@ -69,6 +71,13 @@ class BaseIMU(BaseSensor):
         # Use ENU
         self.use_enu: bool = self.USE_ENU
         self.set_use_enu(use_enu)
+        # ROS Parameter Template
+        template = {
+            self.ROS_PARAMETERS_KEYS.FRAME_ID: BaseIMU.frame_id,
+            self.ROS_PARAMETERS_KEYS.PORT: BaseIMU.port,
+            self.ROS_PARAMETERS_KEYS.USE_ENU: BaseIMU.use_enu,
+        }
+        ros_parameters_template = extend_flat_dict(template, ros_parameters_template)
         super().__init__(
             idx,
             name,
@@ -76,39 +85,11 @@ class BaseIMU(BaseSensor):
             urdf_enabled,
             launch_enabled,
             ros_parameters,
+            ros_parameters_template,
             parent,
             xyz,
             rpy
         )
-        # ROS Parameter Keys
-        pairs = {
-            # Frame ID
-            self.ROS_PARAMETERS_KEYS.FRAME_ID: (
-                BaseSensor.ROSParameter(
-                    key=self.ROS_PARAMETERS_KEYS.FRAME_ID,
-                    get=lambda obj: obj.get_frame_id(),
-                    set=lambda obj, val: obj.set_frame_id(val)
-                )
-            ),
-            # Port
-            self.ROS_PARAMETERS_KEYS.PORT: (
-                BaseSensor.ROSParameter(
-                    key=self.ROS_PARAMETERS_KEYS.PORT,
-                    get=lambda obj: obj.get_port(),
-                    set=lambda obj, val: obj.set_port(val)
-                )
-            ),
-            # Use ENU
-            self.ROS_PARAMETERS_KEYS.USE_ENU: (
-                BaseSensor.ROSParameter(
-                    key=self.ROS_PARAMETERS_KEYS.USE_ENU,
-                    get=lambda obj: obj.get_use_enu(),
-                    set=lambda obj, val: obj.set_use_enu(val)
-                )
-            )
-        }
-        self.ros_parameter_pairs.update(pairs)
-        self.set_ros_parameters(ros_parameters)
 
     @classmethod
     def get_frame_id_from_idx(cls, idx: int) -> str:
@@ -125,18 +106,42 @@ class BaseIMU(BaseSensor):
             self.FRAME_ID
         ))
 
+    @property
+    def frame_id(self) -> str:
+        return self._frame_id
+
+    @frame_id.setter
+    def frame_id(self, link: str) -> None:
+        Accessory.assert_valid_link(link)
+        self._frame_id = link
+
     def get_frame_id(self) -> str:
         return self.frame_id
 
     def set_frame_id(self, link: str) -> None:
-        Accessory.assert_valid_link(link)
         self.frame_id = link
 
+    @property
+    def port(self) -> str:
+        return str(self._port)
+
+    @port.setter
+    def port(self, file: str) -> None:
+        self._port = File(file)
+
     def get_port(self) -> str:
-        return str(self.port)
+        return self.port
 
     def set_port(self, file: str) -> None:
-        self.port = File(file)
+        self.port = file
+
+    @property
+    def use_enu(self) -> bool:
+        return self._use_enu
+
+    @use_enu.setter
+    def use_enu(self, enu: bool) -> None:
+        self._use_enu = bool(enu)
 
     def get_use_enu(self) -> bool:
         return self.use_enu
@@ -151,6 +156,11 @@ class Microstrain(BaseIMU):
     PORT = "/dev/microstrain_main"
     FRAME_ID = "link"
     USE_ENU = True
+
+    class ROS_PARAMETERS_KEYS:
+        PORT = "microstrain_inertial_driver.port"
+        FRAME_ID = "microstrain_inertial_driver.imu_frame_id"
+        USE_ENU = "microstrain_inertial_driver.use_enu_frame"
 
     def __init__(
             self,
@@ -167,6 +177,7 @@ class Microstrain(BaseIMU):
             xyz: List[float] = Accessory.XYZ,
             rpy: List[float] = Accessory.RPY
             ) -> None:
+        ros_parameters_template = BaseSensor.ROS_PARAMETERS_TEMPLATE
         super().__init__(
             idx,
             name,
@@ -177,14 +188,8 @@ class Microstrain(BaseIMU):
             urdf_enabled,
             launch_enabled,
             ros_parameters,
+            ros_parameters_template,
             parent,
             xyz,
             rpy
         )
-        # ROS Parameter Keys
-        self.ros_parameter_pairs[
-            BaseIMU.ROS_PARAMETERS_KEYS.FRAME_ID].key = "imu_frame_id"
-        self.ros_parameter_pairs[
-            BaseIMU.ROS_PARAMETERS_KEYS.PORT].key = "port"
-        self.ros_parameter_pairs[
-            BaseIMU.ROS_PARAMETERS_KEYS.USE_ENU].key = "use_enu_frame"

--- a/clearpath_config/sensors/types/sensor.py
+++ b/clearpath_config/sensors/types/sensor.py
@@ -26,7 +26,12 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 from clearpath_config.common.types.accessory import Accessory, IndexedAccessory
+from clearpath_config.common.utils.dictionary import (
+    flatten_dict,
+    unflatten_dict
+)
 from typing import List, Callable
+import copy
 
 
 class BaseSensor(IndexedAccessory):
@@ -36,6 +41,7 @@ class BaseSensor(IndexedAccessory):
     URDF_ENABLED = True
     LAUNCH_ENABLED = True
     ROS_PARAMETERS = {}
+    ROS_PARAMETERS_TEMPLATE = {}
 
     class ROSParameter:
         def __init__(
@@ -55,7 +61,8 @@ class BaseSensor(IndexedAccessory):
             topic: str = TOPIC,
             urdf_enabled: bool = URDF_ENABLED,
             launch_enabled: bool = LAUNCH_ENABLED,
-            ros_parameters: str = ROS_PARAMETERS,
+            ros_parameters: dict = ROS_PARAMETERS,
+            ros_parameters_template: dict = ROS_PARAMETERS_TEMPLATE,
             parent: str = Accessory.PARENT,
             xyz: List[float] = Accessory.XYZ,
             rpy: List[float] = Accessory.RPY,
@@ -75,9 +82,8 @@ class BaseSensor(IndexedAccessory):
         self.enable_launch if launch_enabled else self.disable_launch()
         # ROS Parameters
         # - dictionary with parameters for launch file
-        self.ros_parameters = {}
-        self.ros_parameter_pairs = {}
-        self.set_ros_parameters(ros_parameters)
+        self.ros_parameters_template = ros_parameters_template
+        self.ros_parameters = ros_parameters
         super().__init__(idx, name, parent, xyz, rpy)
 
     def to_dict(self) -> dict:
@@ -167,16 +173,45 @@ class BaseSensor(IndexedAccessory):
     def get_launch_enabled(self) -> bool:
         return self.launch_enabled
 
-    def set_ros_parameters(self, ros_parameters: dict) -> None:
-        assert isinstance(ros_parameters, dict), (
-            "ROS paramaters must be a dictionary")
-        for key, val in ros_parameters.items():
-            for _, param in self.ros_parameter_pairs.items():
-                if key == param.key:
-                    param.set(self, val)
-        self.ros_parameters = ros_parameters
+    @property
+    def ros_parameters_template(self) -> dict:
+        return self._ros_parameters_template
+
+    @ros_parameters_template.setter
+    def ros_parameters_template(self, d: dict) -> None:
+        assert isinstance(d, dict), ("Template must be of type 'dict'")
+        # Check that template has all properties
+        flat = flatten_dict(d)
+        for _, val in flat.items():
+            assert isinstance(val, property), (
+                "All entries in template must be properties."
+            )
+        self._ros_parameters_template = d
+
+    @property
+    def ros_parameters(self) -> dict:
+        d = flatten_dict(copy.deepcopy(self._ros_parameters))
+        for key, prop in flatten_dict(self.ros_parameters_template).items():
+            d[key] = self.getter(prop)()
+        return unflatten_dict(d)
+
+    @ros_parameters.setter
+    def ros_parameters(self, d: dict) -> None:
+        assert isinstance(d, dict), ("ROS paramaters must be a dictionary")
+        for d_k, d_v in flatten_dict(d).items():
+            for key, prop in flatten_dict(self.ros_parameters_template).items():
+                if d_k == key:
+                    self.setter(prop)(d_v)
+        self._ros_parameters = d
+
+    def set_ros_parameters(self, d: dict) -> None:
+        self.ros_parameters = d
 
     def get_ros_parameters(self) -> dict:
-        for _, param in self.ros_parameter_pairs.items():
-            self.ros_parameters[param.key] = param.get(self)
         return self.ros_parameters
+
+    def setter(self, prop: property):
+        return prop.fset.__get__(self)
+
+    def getter(self, prop: property):
+        return prop.fget.__get__(self)

--- a/clearpath_config/sensors/types/sensor.py
+++ b/clearpath_config/sensors/types/sensor.py
@@ -193,7 +193,10 @@ class BaseSensor(IndexedAccessory):
         d = flatten_dict(copy.deepcopy(self._ros_parameters))
         for key, prop in flatten_dict(self.ros_parameters_template).items():
             d[key] = self.getter(prop)()
-        return unflatten_dict(d)
+        d = unflatten_dict(d)
+        for node_name in d:
+            d[node_name] = flatten_dict(d[node_name])
+        return d
 
     @ros_parameters.setter
     def ros_parameters(self, d: dict) -> None:

--- a/clearpath_config/system/hosts.py
+++ b/clearpath_config/system/hosts.py
@@ -103,6 +103,18 @@ class HostsConfig(BaseConfig):
         # Set from Config
         super().__init__(setters, config, self.HOSTS)
 
+    def update(self, serial_number=False) -> None:
+        if serial_number:
+            sn = BaseConfig._SERIAL_NUMBER.get_serial()
+            # Update if still defaults
+            if self.self == self.DEFAULTS[self.SELF]:
+                self.self = sn
+            if self.platform.get_hostname() == sn:
+                self.platform.set_hostname(sn)
+            # Update Defaults
+            self.DEFAULTS[self.SELF] = sn
+            self.DEFAULTS[self.PLATFORM] = {sn: "192.168.131.1"}
+
     # Self:
     # - the hostname of the computer running this config
     @property

--- a/clearpath_config/system/hosts.py
+++ b/clearpath_config/system/hosts.py
@@ -72,9 +72,9 @@ class HostsConfig(BaseConfig):
     KEYS = flip_dict(TEMPLATE)
 
     DEFAULTS = {
-        SELF: BaseConfig._SERIAL_NUMBER.get_serial(),
+        SELF: BaseConfig.get_serial_number(),
         PLATFORM: {
-            BaseConfig._SERIAL_NUMBER.get_serial(): "192.168.131.1"
+            BaseConfig.get_serial_number(): "192.168.131.1"
         },
         ONBOARD: {},
         REMOTE: {}
@@ -105,7 +105,7 @@ class HostsConfig(BaseConfig):
 
     def update(self, serial_number=False) -> None:
         if serial_number:
-            sn = BaseConfig._SERIAL_NUMBER.get_serial()
+            sn = BaseConfig.get_serial_number()
             # Update if still defaults
             if self.self == self.DEFAULTS[self.SELF]:
                 self.self = sn

--- a/clearpath_config/system/system.py
+++ b/clearpath_config/system/system.py
@@ -68,7 +68,7 @@ class SystemConfig(BaseConfig):
         # USERNAME: administrator
         USERNAME: "administrator",
         # NAMESPACE: serial number
-        NAMESPACE: Namespace.clean(str(BaseConfig._SERIAL_NUMBER)),
+        NAMESPACE: Namespace.clean(BaseConfig.get_serial_number(prefix=True)),
         # DOMAIN_ID: 0
         DOMAIN_ID: 0,
         # RMW: "rmw_fastrtps_cpp"
@@ -111,7 +111,7 @@ class SystemConfig(BaseConfig):
         if serial_number:
             self.hosts.update(serial_number=serial_number)
             # Update if still defaults
-            namespace = Namespace.clean(str(BaseConfig._SERIAL_NUMBER))
+            namespace = Namespace.clean(self.get_serial_number(prefix=True))
             if self.namespace == self.DEFAULTS[self.NAMESPACE]:
                 self.namespace = namespace
             # Update defaults

--- a/clearpath_config/system/system.py
+++ b/clearpath_config/system/system.py
@@ -107,6 +107,16 @@ class SystemConfig(BaseConfig):
         # Set from Config
         super().__init__(setters, config, self.SYSTEM)
 
+    def update(self, serial_number=False) -> None:
+        if serial_number:
+            self.hosts.update(serial_number=serial_number)
+            # Update if still defaults
+            namespace = Namespace.clean(str(BaseConfig._SERIAL_NUMBER))
+            if self.namespace == self.DEFAULTS[self.NAMESPACE]:
+                self.namespace = namespace
+            # Update defaults
+            self.DEFAULTS[self.NAMESPACE] = namespace
+
     @property
     def hosts(self) -> HostsConfig:
         self.set_config_param(

--- a/clearpath_config/tests/test_samples.py
+++ b/clearpath_config/tests/test_samples.py
@@ -64,9 +64,9 @@ class TestPlatformSamples:
             except AssertionError as ae:
                 errors.append("A200 sample failed to load: %s" % ae.args[0])
             else:
-                if cc.get_model() != Platform.A200:
+                if cc.get_platform_model() != Platform.A200:
                     errors.append("Platform model does not match. %s =/= %s" % (
-                        cc.get_model(),
+                        cc.get_platform_model(),
                         Platform.A200
                     ))
         assert_not_errors(errors)
@@ -79,7 +79,7 @@ class TestPlatformSamples:
             except AssertionError as ae:
                 errors.append("J100 sample failed to load: %s" % ae.args[0])
             else:
-                if cc.get_model() != Platform.J100:
+                if cc.get_platform_model() != Platform.J100:
                     errors.append("Platform model does not match. %s =/= %s" % (
                         cc.get_model(),
                         Platform.J100


### PR DESCRIPTION
Fixes:
 - default index for GPS and IMU on Jackal is incremented
 - default namespace and hostname updated to match serial number

Changes:
 - changed `ros_parameters` to require a node to be passed

Additions: 
 - added NMEA GPS (Garmin 18x and Novatel Smart[6&7])
