### PR TITLE
Find packages for meshes / extras urdf

### DIFF
--- a/clearpath_config/common/types/file.py
+++ b/clearpath_config/common/types/file.py
@@ -31,12 +31,12 @@ import os
 # File
 # - file class
 class File:
-    def __init__(self, path: str, creatable=False, exists=False) -> None:
+    def __init__(self, path: str, creatable=False, exists=False, make_abs=True) -> None:
         if creatable:
             assert File.is_creatable(path)
         if exists:
             assert File.is_exists(path)
-        self.path = File.clean(path)
+        self.path = File.clean(path, make_abs)
 
     def __str__(self) -> str:
         return self.path
@@ -50,23 +50,24 @@ class File:
             return False
 
     @staticmethod
-    def clean(path: str) -> str:
+    def clean(path: str, make_abs=True) -> str:
         if not path:
             return ""
         path = os.path.expanduser(path)
         path = os.path.normpath(path)
-        path = os.path.abspath(path)
+        if make_abs:
+            path = os.path.abspath(path)
         return path
 
     @staticmethod
-    def is_creatable(path: str) -> bool:
-        path = File.clean(path)
+    def is_creatable(path: str, make_abs=True) -> bool:
+        path = File.clean(path, make_abs)
         dirname = os.path.dirname(path) or os.getcwd()
         return os.access(dirname, os.W_OK)
 
     @staticmethod
-    def is_exists(path: str) -> bool:
-        path = File.clean(path)
+    def is_exists(path: str, make_abs=True) -> bool:
+        path = File.clean(path, make_abs)
         return os.path.exists(path)
 
     def get_path(self) -> str:

--- a/clearpath_config/common/types/package_path.py
+++ b/clearpath_config/common/types/package_path.py
@@ -25,53 +25,46 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from clearpath_config.common.types.accessory import Accessory
-from clearpath_config.links.types.link import BaseLink
-from clearpath_config.common.types.package_path import PackagePath
-from typing import List
+
+from clearpath_config.common.types.file import File
 
 
-class Mesh(BaseLink):
-    LINK_TYPE = "mesh"
-    VISUAL = ""
-    # COLLISION = "empty.stl"
+class PackagePath:
+    PACKAGE = "package"
+    PATH = "path"
 
     def __init__(
             self,
-            name: str,
-            parent: str = Accessory.PARENT,
-            visual: dict = VISUAL,
-            # collision: float = COLLISION,
-            xyz: List[float] = Accessory.XYZ,
-            rpy: List[float] = Accessory.RPY,
-            offset_xyz: List[float] = BaseLink.OFFSET_XYZ,
-            offset_rpy: List[float] = BaseLink.OFFSET_RPY
+            package: str = None,
+            path: str = None,
             ) -> None:
-        super().__init__(
-            name,
-            parent,
-            xyz,
-            rpy,
-            offset_xyz,
-            offset_rpy
-        )
+        self.package = package
+        self.path = File.clean(path, make_abs=False)
 
-        self.visual: PackagePath = PackagePath(Mesh.VISUAL)
-        self.set_visual(visual)
+    def from_dict(self, config: dict) -> None:
+        if self.PACKAGE in config:
+            self.package = config[self.PACKAGE]
+        if self.PATH in config:
+            self.path = config[self.PATH]
 
     def to_dict(self) -> dict:
-        d = super().to_dict()
-        d['visual'] = self.get_visual()
-        return d
+        return {
+            self.PACKAGE: self.package,
+            self.PATH: self.path,
+        }
 
-    def from_dict(self, d: dict) -> None:
-        super().from_dict(d)
-        if 'visual' in d:
-            self.set_visual(d['visual'])
+    @property
+    def package(self) -> str:
+        return self._package
 
-    def set_visual(self, visual: dict) -> None:
-        if visual:
-            self.visual.from_dict(visual)
+    @package.setter
+    def package(self, value: str) -> None:
+        self._package = value
 
-    def get_visual(self) -> dict:
-        return self.visual.to_dict()
+    @property
+    def path(self) -> str:
+        return self._path
+
+    @path.setter
+    def path(self, value: str) -> None:
+        self._path = value

--- a/clearpath_config/links/links.py
+++ b/clearpath_config/links/links.py
@@ -497,7 +497,8 @@ class LinksConfig(BaseConfig):
             mesh: Mesh = None,
             # By Parameters
             name: str = None,
-            visual: float = Mesh.VISUAL,
+            visual: str = Mesh.VISUAL,
+            package: str = Mesh.PACKAGE,
             parent: str = Accessory.PARENT,
             xyz: List[float] = Accessory.XYZ,
             rpy: List[float] = Accessory.RPY,
@@ -511,6 +512,7 @@ class LinksConfig(BaseConfig):
             mesh = Mesh(
                 name=name,
                 visual=visual,
+                package=package,
                 parent=parent,
                 xyz=xyz,
                 rpy=rpy,

--- a/clearpath_config/links/links.py
+++ b/clearpath_config/links/links.py
@@ -497,8 +497,7 @@ class LinksConfig(BaseConfig):
             mesh: Mesh = None,
             # By Parameters
             name: str = None,
-            visual: str = Mesh.VISUAL,
-            package: str = Mesh.PACKAGE,
+            visual: dict = Mesh.VISUAL,
             parent: str = Accessory.PARENT,
             xyz: List[float] = Accessory.XYZ,
             rpy: List[float] = Accessory.RPY,
@@ -512,7 +511,6 @@ class LinksConfig(BaseConfig):
             mesh = Mesh(
                 name=name,
                 visual=visual,
-                package=package,
                 parent=parent,
                 xyz=xyz,
                 rpy=rpy,

--- a/clearpath_config/links/types/mesh.py
+++ b/clearpath_config/links/types/mesh.py
@@ -25,6 +25,8 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+import os
+
 from clearpath_config.common.types.accessory import Accessory
 from clearpath_config.common.types.file import File
 from clearpath_config.links.types.link import BaseLink
@@ -34,13 +36,15 @@ from typing import List
 class Mesh(BaseLink):
     LINK_TYPE = "mesh"
     VISUAL = "empty.stl"
+    PACKAGE = ""
     # COLLISION = "empty.stl"
 
     def __init__(
             self,
             name: str,
             parent: str = Accessory.PARENT,
-            visual: float = VISUAL,
+            visual: str = VISUAL,
+            package: str = PACKAGE,
             # collision: float = COLLISION,
             xyz: List[float] = Accessory.XYZ,
             rpy: List[float] = Accessory.RPY,
@@ -55,8 +59,9 @@ class Mesh(BaseLink):
             offset_xyz,
             offset_rpy
         )
-        self.visual: File = File(Mesh.VISUAL)
-        self.set_visual(visual)
+
+        self.visual: str = Mesh.VISUAL
+        self.set_visual(visual, package)
 
     def to_dict(self) -> dict:
         d = super().to_dict()
@@ -66,10 +71,17 @@ class Mesh(BaseLink):
     def from_dict(self, d: dict) -> None:
         super().from_dict(d)
         if 'visual' in d:
-            self.set_visual(d['visual'])
+            if 'package' in d:
+                self.set_visual(d['visual'], d['package'])
+            else:
+                self.set_visual(d['visual'])
 
-    def set_visual(self, visual: str) -> None:
-        self.visual = File(visual)
+    def set_visual(self, visual: str, package: str = "") -> None:
+        if package:
+            self.visual = os.path.join("$(find " + package + ")",
+                                       File.clean(visual, make_abs=False))
+        else:
+            self.visual = File.clean(visual, make_abs=True)
 
     def get_visual(self) -> str:
-        return self.visual.get_path()
+        return self.visual

--- a/clearpath_config/platform/platform.py
+++ b/clearpath_config/platform/platform.py
@@ -27,52 +27,12 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from clearpath_config.common.types.platform import Platform
 from clearpath_config.common.types.config import BaseConfig
+from clearpath_config.common.types.package_path import PackagePath
 from clearpath_config.common.utils.dictionary import flip_dict
 from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.extras import ExtrasConfig
 from clearpath_config.platform.attachments.config import AttachmentsConfig
 from clearpath_config.platform.attachments.mux import AttachmentsConfigMux
-
-
-class PackagePath:
-    PACKAGE = "package"
-    PATH = "path"
-
-    def __init__(
-            self,
-            package: str = None,
-            path: str = None,
-            ) -> None:
-        self.package = package
-        self.path = path
-
-    def from_dict(self, config: dict) -> None:
-        if self.PACKAGE in config:
-            self.package = config[self.PACKAGE]
-        if self.PATH in config:
-            self.path = config[self.PATH]
-
-    def to_dict(self) -> dict:
-        return {
-            self.PACKAGE: self.package,
-            self.PATH: self.path,
-        }
-
-    @property
-    def package(self) -> str:
-        return self._package
-
-    @package.setter
-    def package(self, value: str) -> None:
-        self._package = value
-
-    @property
-    def path(self) -> str:
-        return self._path
-
-    @path.setter
-    def path(self, value: str) -> None:
-        self._path = value
 
 
 class DescriptionPackagePath(PackagePath):


### PR DESCRIPTION

~Non~ Breaking change - *changes discussed in comments below*

This adds the feature to allow users to link mesh files and urdf extra files using the package name and relative link (without breaking the option to give the absolute link only). 

Example robot.yaml excerpts:
```python
platform:
  extras:
    urdf_package: custom_package
    urdf: urdf/custom_urdf.urdf.xacro
links:
  mesh:
    - name: custom_component
      parent: default_mount
      xyz: [0.0, 0.0, 0.0]
      rpy: [0.0, 0.0, 0.0]
      package: custom_package
      visual: meshes/custom_mesh.STL
```

Example of the resulting urdf sections:
```xacro
  <xacro:include filename="$(find clearpath_platform_description)/urdf/links/mesh.urdf.xacro"/>
  <xacro:mesh name="custom_component" parent_link="default_mount" visual="$(find custom_package)/meshes/custom_mesh.STL">
    <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
  </xacro:mesh>

  <!-- Extras -->

  <xacro:include filename="$(find custom_package)/urdf/custom_urdf.urdf.xacro"/>
```


Documentation to come