### PR TITLE
Added battery launch arguments to support launching the valence bms node

### DIFF
--- a/clearpath_config/platform/battery.py
+++ b/clearpath_config/platform/battery.py
@@ -55,6 +55,7 @@ class BatteryConfig(BaseConfig):
 
     # Configurations
     CONFIGURATION = "configuration"
+    LAUNCH_ARGS = 'launch_args'
     S1P1 = "S1P1"
     S1P2 = "S1P2"
     S1P3 = "S1P3"
@@ -101,7 +102,8 @@ class BatteryConfig(BaseConfig):
     TEMPLATE = {
         BATTERY: {
             MODEL: MODEL,
-            CONFIGURATION: CONFIGURATION
+            CONFIGURATION: CONFIGURATION,
+            LAUNCH_ARGS: LAUNCH_ARGS
         }
     }
 
@@ -109,7 +111,8 @@ class BatteryConfig(BaseConfig):
 
     DEFAULTS = {
         MODEL: UNKNOWN,
-        CONFIGURATION: UNKNOWN
+        CONFIGURATION: UNKNOWN,
+        LAUNCH_ARGS: {}
     }
 
     def __init__(
@@ -117,6 +120,7 @@ class BatteryConfig(BaseConfig):
             config: dict = {},
             model: str = DEFAULTS[MODEL],
             configuration: str = DEFAULTS[CONFIGURATION],
+            launch_args: dict = DEFAULTS[LAUNCH_ARGS]
             ) -> None:
         # Initialization
         self._config = {}
@@ -130,10 +134,16 @@ class BatteryConfig(BaseConfig):
             self.configuration = self.DEFAULTS[self.CONFIGURATION]
         else:
             self.configuration = configuration
+        if launch_args == self.DEFAULTS[self.LAUNCH_ARGS] or not launch_args:
+            self.launch_args = self.DEFAULTS[self.LAUNCH_ARGS]
+        else:
+            self.launch_args = launch_args
+
         # Setter Template
         setters = {
             self.KEYS[self.MODEL]: BatteryConfig.model,
             self.KEYS[self.CONFIGURATION]: BatteryConfig.configuration,
+            self.KEYS[self.LAUNCH_ARGS]: BatteryConfig.launch_args,
         }
         super().__init__(setters, config, self.BATTERY)
 
@@ -197,3 +207,19 @@ class BatteryConfig(BaseConfig):
                 platform, self.model, list(self.VALID[platform][self.model]))
         ))
         self._configuration = value
+
+    @property
+    def launch_args(self) -> dict:
+        self.set_config_param(
+            key=self.KEYS[self.LAUNCH_ARGS],
+            value=self._launch_args
+        )
+        return self._launch_args
+
+    @launch_args.setter
+    def launch_args(self, value: dict) -> None:
+        assert isinstance(value, dict), ((
+            "Battery Launch args %s are invalid. " % value +
+            "They must be in the format of a dictionary."
+        ))
+        self._launch_args = value


### PR DESCRIPTION
I'm open to discussion over the naming of this but the idea is that this is similar to ros_parameters in terms of being a dictionary with keys defined in the packages that we are calling, but is more obfuscated because they are parameters going to the battery launch file (which includes other launch files) and is not going directly to particular nodes that are named in the yaml. (Hence why I do not want to call it ros_parameters).

This goes along with a PR for clearpath_robot which will be added once the valence packages are released and therefore can be added as dependencies.