### PR TITLE
Renamed Realsense

### DIFF
--- a/clearpath_config/sensors/types/cameras.py
+++ b/clearpath_config/sensors/types/cameras.py
@@ -258,14 +258,14 @@ class IntelRealsense(BaseCamera):
     POINTCLOUD_ENABLED = True
 
     class ROS_PARAMETER_KEYS:
-        FPS = "camera.rgb_camera.profile"
-        SERIAL = "camera.serial_no"
-        CAMERA_NAME = "camera.camera_name"
-        DEVICE_TYPE = "camera.device_type"
-        DEPTH_PROFILE = "camera.depth_module.profile"
-        DEPTH_ENABLE = "camera.enable_depth"
-        COLOR_ENABLE = "camera.enable_color"
-        POINTCLOUD_ENABLE = "camera.pointcloud.enable"
+        FPS = "intel_realsense.rgb_camera.profile"
+        SERIAL = "intel_realsense.serial_no"
+        CAMERA_NAME = "intel_realsense.camera_name"
+        DEVICE_TYPE = "intel_realsense.device_type"
+        DEPTH_PROFILE = "intel_realsense.depth_module.profile"
+        DEPTH_ENABLE = "intel_realsense.enable_depth"
+        COLOR_ENABLE = "intel_realsense.enable_color"
+        POINTCLOUD_ENABLE = "intel_realsense.pointcloud.enable"
 
     class TOPICS:
         COLOR_IMAGE = "color_image"


### PR DESCRIPTION
Renamed the Realsense's `ros_parameter` entires to match the rename in the node itself. 