### PR TITLE
Fix support for the device_type parameter

### DIFF
--- a/clearpath_config/sensors/types/cameras.py
+++ b/clearpath_config/sensors/types/cameras.py
@@ -1076,6 +1076,7 @@ class AxisCamera(BaseCamera):
         DOME_PTZ,
         DOME_FIXED,
     ]
+    DEFAULT = DOME_FIXED
 
     HOSTNAME = '192.168.10.0'
     HTTP_PORT = 80
@@ -1120,6 +1121,8 @@ class AxisCamera(BaseCamera):
 
     class ROS_PARAMETER_KEYS:
         SERIAL = 'axis_camera.serial'  # required by superclass, not used locally
+
+        DEVICE_TYPE = 'axis_camera.device_type'
 
         TF_PREFIX = 'axis_camera.tf_prefix'
 
@@ -1188,7 +1191,7 @@ class AxisCamera(BaseCamera):
             topic: str = BaseCamera.TOPIC,
             fps: int = FPS,
             serial: str = SERIAL,
-            device_type: str = Q62,
+            device_type: str = DEFAULT,
 
             hostname: str = HOSTNAME,
             http_port: int = HTTP_PORT,
@@ -1242,6 +1245,8 @@ class AxisCamera(BaseCamera):
         # ROS Parameter Template
         ros_parameters_template = {
             self.ROS_PARAMETER_KEYS.SERIAL: AxisCamera.serial,
+
+            self.ROS_PARAMETER_KEYS.DEVICE_TYPE: AxisCamera.device_type,
 
             self.ROS_PARAMETER_KEYS.TF_PREFIX: AxisCamera.tf_prefix,
 


### PR DESCRIPTION
Setting the `device_type` parameter in robot.yaml is not working correctly; the camera is stuck always being a Q62.

This should be backported to Humble too.