### PR TITLE
A300 VCAN

### DIFF
--- a/clearpath_config/platform/can.py
+++ b/clearpath_config/platform/can.py
@@ -148,7 +148,7 @@ class CANBridgeConfig:
 
     A300_DEFAULT = [
         {
-            CANBridge.INTERFACE: 'can0',
+            CANBridge.INTERFACE: 'vcan0',
             CANBridge.ENABLE_CAN_FD: False,
             CANBridge.INTERVAL: 0.01,
             CANBridge.USE_BUS_TIME: False,

--- a/clearpath_config/platform/can.py
+++ b/clearpath_config/platform/can.py
@@ -156,15 +156,16 @@ class CANBridgeConfig:
             CANBridge.AUTO_CONFIGURE: True,
             CANBridge.AUTO_ACTIVATE: True,
         },
-        {
-            CANBridge.INTERFACE: 'vcan1',
-            CANBridge.ENABLE_CAN_FD: False,
-            CANBridge.INTERVAL: 0.01,
-            CANBridge.USE_BUS_TIME: False,
-            CANBridge.FILTERS: '0:0',
-            CANBridge.AUTO_CONFIGURE: True,
-            CANBridge.AUTO_ACTIVATE: True,
-        }
+        # TODO: Re-enable when battery driver uses clearpath_ros2_socketcan_interface
+        # {
+        #     CANBridge.INTERFACE: 'vcan1',
+        #     CANBridge.ENABLE_CAN_FD: False,
+        #     CANBridge.INTERVAL: 0.01,
+        #     CANBridge.USE_BUS_TIME: False,
+        #     CANBridge.FILTERS: '0:0',
+        #     CANBridge.AUTO_CONFIGURE: True,
+        #     CANBridge.AUTO_ACTIVATE: True,
+        # }
     ]
 
     DEFAULTS = {


### PR DESCRIPTION
Switch A300 defaults to use `vcan0` and `vcan1`.

`vcan1` is disabled for now because the battery driver currently opens the socket directly and does not use the socketcan interface.