### PR TITLE
Raise an UnsupportedPlatformException for the Jackal (for now)

### DIFF
--- a/clearpath_config/common/types/platform.py
+++ b/clearpath_config/common/types/platform.py
@@ -134,6 +134,7 @@ class Platform:
             platform == Platform.DD150 or
             platform == Platform.DO100 or
             platform == Platform.DO150 or
+            platform == Platform.J100 or
             platform == Platform.R100
         ):
             raise UnsupportedPlatformException(f'Platform {platform} is still in-development and not yet supported on {ROS_DISTRO}')  # noqa:E501


### PR DESCRIPTION
We don't have Jazzy firmware for it yet, so Jazzy isn't usable on a physical robot right now.