### PR TITLE
Fix manipulator names

### DIFF
--- a/clearpath_config/common/types/accessory.py
+++ b/clearpath_config/common/types/accessory.py
@@ -205,4 +205,4 @@ class IndexedAccessory(Accessory):
     def set_idx(self, idx: int) -> None:
         assert isinstance(idx, int), 'Index must be an integer'
         assert idx >= 0, 'Index must be a positive integer'
-        self.name = self.get_name_from_idx(idx)
+        self.idx = idx

--- a/clearpath_config/manipulators/types/manipulator.py
+++ b/clearpath_config/manipulators/types/manipulator.py
@@ -66,7 +66,7 @@ class BaseManipulator(IndexedAccessory):
         super().__init__(idx, name, parent, xyz, rpy)
 
     def to_dict(self) -> dict:
-        d = {}
+        d = super().to_dict()
         d['model'] = self.get_manipulator_model()
         d['parent'] = self.get_parent()
         d['xyz'] = self.get_xyz()
@@ -75,6 +75,7 @@ class BaseManipulator(IndexedAccessory):
         return d
 
     def from_dict(self, d: dict) -> None:
+        super().from_dict(d)
         if 'parent' in d:
             self.set_parent(d['parent'])
         if 'xyz' in d:


### PR DESCRIPTION
In robot.yaml, name applies to most attachments, but it is ignored for manipulators. Looks like a bug where super wasn't called in the right places.

If you don't specify a name, it works as usual, defaulting to arm_0. Otherwise it uses your name. This is particularly handy when you have multiple robots with arms. Just knowing which arm is which from the name saves a lot of hassle.