### PR TITLE
Add `rgba`, `collision` attributes to `links`

### DIFF
--- a/clearpath_config/common/types/accessory.py
+++ b/clearpath_config/common/types/accessory.py
@@ -132,6 +132,17 @@ class Accessory():
         assert all([isinstance(i, float) for i in tri])  # noqa:C419
 
     @staticmethod
+    def assert_valid_quadruple(quad: List[float], msg: str = None) -> None:
+        if msg is None:
+            msg = 'Quadruple must be a list of four float values'
+        # Quad must be a list
+        assert isinstance(quad, list), msg
+        # Quad must have a length of 4
+        assert len(quad) == 4, msg
+        # Quad must be all floats
+        assert all([isinstance(i, float) for i in quad])  # noqa:C419
+
+    @staticmethod
     def assert_is_supported():
         """
         Override this method to temporarily disable accessories that are not currently supported.

--- a/clearpath_config/links/types/link.py
+++ b/clearpath_config/links/types/link.py
@@ -59,7 +59,8 @@ class BaseLink(Accessory):
     LINK_TYPE = 'base'
     OFFSET_XYZ = [0.0, 0.0, 0.0]
     OFFSET_RPY = [0.0, 0.0, 0.0]
-    rgba = [0.2, 0.2, 0.2, 1.0]  # clearpath_dark_grey
+    RGBA = [0.2, 0.2, 0.2, 1.0]  # clearpath_dark_grey
+    COLLISION_ENABLE = True
 
     def __init__(
         self,
@@ -69,7 +70,8 @@ class BaseLink(Accessory):
         rpy: List[float] = Accessory.RPY,
         offset_xyz: List[float] = OFFSET_XYZ,
         offset_rpy: List[float] = OFFSET_RPY,
-        rgba: List[float] = rgba,
+        rgba: List[float] = RGBA,
+        collision_enable: bool = COLLISION_ENABLE,
     ) -> None:
         super().__init__(name, parent, xyz, rpy)
         self.offset_xyz: List[float] = BaseLink.OFFSET_XYZ
@@ -77,6 +79,7 @@ class BaseLink(Accessory):
         self.offset_rpy: List[float] = BaseLink.OFFSET_RPY
         self.set_offset_rpy(offset_rpy)
         self.set_rgba(rgba)
+        self.set_collision_enable(collision_enable)
 
     def to_dict(self) -> dict:
         d = {}
@@ -85,6 +88,7 @@ class BaseLink(Accessory):
         d['xyz'] = self.get_xyz()
         d['rpy'] = self.get_rpy()
         d['rgba'] = self.get_rgba()
+        d['collision'] = self.get_collision_enable()
         return d
 
     def from_dict(self, d: dict) -> None:
@@ -98,6 +102,8 @@ class BaseLink(Accessory):
             self.set_rpy(d['rpy'])
         if 'rgba' in d:
             self.set_rgba(d['rgba'])
+        if 'collision' in d:
+            self.set_collision_enable(d['collision'])
 
     @classmethod
     def get_link_type(cls) -> str:
@@ -130,3 +136,8 @@ class BaseLink(Accessory):
         )
         self.rgba = rgba
 
+    def get_collision_enable(self) -> bool:
+        return self.collision_enable
+
+    def set_collision_enable(self, enable: bool) -> None:
+        self.collision_enable = enable

--- a/clearpath_config/links/types/link.py
+++ b/clearpath_config/links/types/link.py
@@ -59,21 +59,24 @@ class BaseLink(Accessory):
     LINK_TYPE = 'base'
     OFFSET_XYZ = [0.0, 0.0, 0.0]
     OFFSET_RPY = [0.0, 0.0, 0.0]
+    rgba = [0.2, 0.2, 0.2, 1.0]  # clearpath_dark_grey
 
     def __init__(
-            self,
-            name: str,
-            parent: str = Accessory.PARENT,
-            xyz: List[float] = Accessory.XYZ,
-            rpy: List[float] = Accessory.RPY,
-            offset_xyz: List[float] = OFFSET_XYZ,
-            offset_rpy: List[float] = OFFSET_RPY
-            ) -> None:
+        self,
+        name: str,
+        parent: str = Accessory.PARENT,
+        xyz: List[float] = Accessory.XYZ,
+        rpy: List[float] = Accessory.RPY,
+        offset_xyz: List[float] = OFFSET_XYZ,
+        offset_rpy: List[float] = OFFSET_RPY,
+        rgba: List[float] = rgba,
+    ) -> None:
         super().__init__(name, parent, xyz, rpy)
         self.offset_xyz: List[float] = BaseLink.OFFSET_XYZ
         self.set_offset_xyz(offset_xyz)
         self.offset_rpy: List[float] = BaseLink.OFFSET_RPY
         self.set_offset_rpy(offset_rpy)
+        self.set_rgba(rgba)
 
     def to_dict(self) -> dict:
         d = {}
@@ -81,6 +84,7 @@ class BaseLink(Accessory):
         d['parent'] = self.get_parent()
         d['xyz'] = self.get_xyz()
         d['rpy'] = self.get_rpy()
+        d['rgba'] = self.get_rgba()
         return d
 
     def from_dict(self, d: dict) -> None:
@@ -92,6 +96,8 @@ class BaseLink(Accessory):
             self.set_xyz(d['xyz'])
         if 'rpy' in d:
             self.set_rpy(d['rpy'])
+        if 'rgba' in d:
+            self.set_rgba(d['rgba'])
 
     @classmethod
     def get_link_type(cls) -> str:
@@ -113,3 +119,14 @@ class BaseLink(Accessory):
             'Offset RPY must be a list of exactly three float values'
         )
         self.offset_rpy = rpy
+
+    def get_rgba(self) -> List[float]:
+        return self.rgba
+
+    def set_rgba(self, rgba: List[float]) -> None:
+        Accessory.assert_valid_quadruple(
+            rgba,
+            'RGBA must be a list of exactly 4 float values'
+        )
+        self.rgba = rgba
+


### PR DESCRIPTION
Adds 2 quality-of-life updates to the `links` section of robot.yaml:
- `rgba`: a four-tuple of floats to specify the desired colour of the link's visual (defaults to the previous `clearpath_dark_grey`)
- `collision`: a boolean that can be used to turn off collision geometry (defaults to `true`)

Multi-part change:
- https://github.com/clearpathrobotics/clearpath_common/pull/205
- https://github.com/clearpathrobotics/clearpath_config/pull/162