### PR TITLE
Fix: Overwrite defined values with ROS parameters

### DIFF
--- a/clearpath_config/sensors/types/sensor.py
+++ b/clearpath_config/sensors/types/sensor.py
@@ -230,7 +230,10 @@ class BaseSensor(IndexedAccessory):
     def ros_parameters(self) -> dict:
         d = flatten_dict(copy.deepcopy(self._ros_parameters))
         for key, prop in flatten_dict(self.ros_parameters_template).items():
-            d[key] = self.getter(prop)()
+            # If defined by user, do not overwrite
+            if key not in d:
+                d[key] = self.getter(prop)()
+            # d[key] = self.getter(prop)()
         d = unflatten_dict(d)
         for node_name in d:
             d[node_name] = flatten_dict(d[node_name])

--- a/clearpath_config/sensors/types/sensor.py
+++ b/clearpath_config/sensors/types/sensor.py
@@ -233,7 +233,6 @@ class BaseSensor(IndexedAccessory):
             # If defined by user, do not overwrite
             if key not in d:
                 d[key] = self.getter(prop)()
-            # d[key] = self.getter(prop)()
         d = unflatten_dict(d)
         for node_name in d:
             d[node_name] = flatten_dict(d[node_name])


### PR DESCRIPTION
Pass ROS parameters exactly as defined in the `robot.yaml`. This will allow users to overwrite defaults, specifically `name` parameters, that are set by the configuration system to ensure that the naming scheme is consistent. While this could allow users to "break" the configuration, it will give more experienced users the ability to fully customise the node launches. 