### PR TITLE
Fix: OAK-D Parameters 

### DIFF
--- a/clearpath_config/sensors/types/cameras.py
+++ b/clearpath_config/sensors/types/cameras.py
@@ -838,7 +838,7 @@ class StereolabsZed(BaseCamera):
 class LuxonisOAKD(BaseCamera):
     SENSOR_MODEL = 'luxonis_oakd'
 
-    SERIAL = None
+    SERIAL = ''
 
     PRO = 'pro'
     LITE = 'lite'


### PR DESCRIPTION
Set default OakD serial number to empty string