### PR TITLE
Rename `oakd` namespace in robot.yaml to `luxonis_oakd`

### DIFF
--- a/clearpath_config/sample/a300/a300_amp.yaml
+++ b/clearpath_config/sample/a300/a300_amp.yaml
@@ -62,7 +62,7 @@ sensors:
       launch_enabled: true
       parent: sensor_arch_front_camera_mount
       ros_parameters:
-        oakd:
+        luxonis_oakd:
           device_type: pro_w_poe
           camera:
             i_enable_imu: false
@@ -93,7 +93,7 @@ sensors:
       launch_enabled: true
       parent: sensor_arch_rear_camera_mount
       ros_parameters:
-        oakd:
+        luxonis_oakd:
           device_type: pro_w_poe
           camera:
             i_enable_imu: false

--- a/clearpath_config/sample/a300/a300_observer.yaml
+++ b/clearpath_config/sample/a300/a300_observer.yaml
@@ -64,7 +64,7 @@ sensors:
       launch_enabled: true
       parent: sensor_arch_front_camera_mount
       ros_parameters:
-        oakd:
+        luxonis_oakd:
           device_type: pro_w_poe
           camera:
             i_enable_imu: false
@@ -95,7 +95,7 @@ sensors:
       launch_enabled: true
       parent: sensor_arch_rear_camera_mount
       ros_parameters:
-        oakd:
+        luxonis_oakd:
           device_type: pro_w_poe
           camera:
             i_enable_imu: false

--- a/clearpath_config/sample/sensors/luxonis_oakd.yaml
+++ b/clearpath_config/sample/sensors/luxonis_oakd.yaml
@@ -9,7 +9,7 @@ sensors:
     xyz: [0.0, 0.0, 0.0]
     rpy: [0.0, 0.0, 0.0]
     ros_parameters:
-      oakd:
+      luxonis_oakd:
         camera:
           i_enable_imu: false
           i_enable_ir: false

--- a/clearpath_config/sensors/types/cameras.py
+++ b/clearpath_config/sensors/types/cameras.py
@@ -849,20 +849,20 @@ class LuxonisOAKD(BaseCamera):
     FPS = 30.0
 
     class ROS_PARAMETER_KEYS:
-        DEVICE_TYPE = 'oakd.device_type'
+        DEVICE_TYPE = 'luxonis_oakd.device_type'
 
         # RGB parameters
-        FPS = 'oakd.rgb.i_fps'
-        HEIGHT = 'oakd.rgb.i_height'
-        WIDTH = 'oakd.rgb.i_width'
+        FPS = 'luxonis_oakd.rgb.i_fps'
+        HEIGHT = 'luxonis_oakd.rgb.i_height'
+        WIDTH = 'luxonis_oakd.rgb.i_width'
 
         # Stereo parameters
-        STEREO_FPS = 'oakd.stereo.i_fps'
+        STEREO_FPS = 'luxonis_oakd.stereo.i_fps'
 
         # General camera parameters
-        IP_ADDRESS = 'oakd.camera.i_ip'
-        MX_ID = 'oakd.camera.i_mx_id'
-        SERIAL = 'oakd.camera.i_usb_port_id'
+        IP_ADDRESS = 'luxonis_oakd.camera.i_ip'
+        MX_ID = 'luxonis_oakd.camera.i_mx_id'
+        SERIAL = 'luxonis_oakd.camera.i_usb_port_id'
 
     class TOPICS:
         COLOR_IMAGE = 'color_image'


### PR DESCRIPTION
The oakd parameter generator wasn't properly converting ROS parameters set in robot.yaml, which was resulting in parameters either being dropped completely or their customized values not matching what's in robot.yaml.

Renaming the namespace to `luxonis_oakd` appears to resolve this, and stays consistent with the style established in e.g. `flir_blackfly`.

Part of RPSW-2760