### PR TITLE
Multiple extra launch files

### DIFF
--- a/clearpath_config/platform/extras.py
+++ b/clearpath_config/platform/extras.py
@@ -25,6 +25,8 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+from typing import List
+
 from clearpath_config.common.types.config import BaseConfig
 from clearpath_config.common.types.package_path import PackagePath
 from clearpath_config.common.types.platform import Platform
@@ -33,6 +35,8 @@ from clearpath_config.common.utils.dictionary import (
     flip_dict,
     unflatten_dict,
 )
+
+from clearpath_config.platform.launch import LaunchConfig
 
 
 class ROSParameterDefaults:
@@ -207,7 +211,7 @@ class ExtrasConfig(BaseConfig):
 
     DEFAULTS = {
         URDF: None,
-        LAUNCH: None,
+        LAUNCH: [],
         ROS_PARAMETERS: ROSParameterDefaults(BaseConfig.get_platform_model()),
     }
 
@@ -272,29 +276,30 @@ class ExtrasConfig(BaseConfig):
             )
 
     @property
-    def launch(self) -> dict:
-        if (self._launch == self.DEFAULTS[self.LAUNCH]):
-            launch = None
-        else:
-            launch = dict(self._launch.to_dict())
-        self.set_config_param(
-            key=self.KEYS[self.LAUNCH],
-            value=launch,
-        )
-        return launch
+    def launch(self) -> List[LaunchConfig]:
+        return self._launch
 
     @launch.setter
-    def launch(self, value: dict | PackagePath) -> None:
-        if isinstance(value, dict) and PackagePath.PATH in value and value[PackagePath.PATH]:
-            self._launch = PackagePath()
-            self._launch.from_dict(value)
-        elif isinstance(value, PackagePath) and value.path:
-            self._launch = value
-        else:
-            self._launch = self.DEFAULTS[self.LAUNCH]
-            assert not value or isinstance(value, dict) or (isinstance(value, PackagePath)), (
-                'Extras LAUNCH must be null or of type `dict` or `PackagePath`'
-            )
+    def launch(self, value: List[LaunchConfig] | List[dict] | LaunchConfig | dict) -> None:
+        # Previously only a single launch file was supported
+        # For compatibility, transform the old format to the new one, but print a deprecation
+        # notice, as this translation layer may be removed in the future
+        if isinstance(value, dict) or isinstance(value, LaunchConfig):
+            print('Deprecation notice: platform.extras.launch should be a list')
+            value = [value]
+
+        self._launch = []
+        for path in value:
+            if isinstance(path, dict) and path.get(LaunchConfig.PATH, ''):
+                pp = LaunchConfig()
+                pp.from_dict(path)
+                self._launch.append(pp)
+            elif isinstance(path, LaunchConfig) and path.path:
+                self._launch.append(path)
+            else:
+                assert not path or isinstance(path, dict) or isinstance(path, LaunchConfig), (
+                    'Extras LAUNCH must be list of type "dict" or "LaunchConfig"'
+                )
 
     def _is_ros_parameter(self, key) -> bool:
         return any([key in i for i in self._ros_parameters_setters])  # noqa:C419

--- a/clearpath_config/platform/launch.py
+++ b/clearpath_config/platform/launch.py
@@ -1,0 +1,121 @@
+# Software License Agreement (BSD)
+#
+# @author    Chris Iverach-Brereton <civerachb@clearpathrobotics.com>
+# @copyright (c) 2025, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from clearpath_config.common.types.config import BaseConfig
+from clearpath_config.common.utils.dictionary import (
+    flip_dict,
+)
+
+
+class LaunchConfig(BaseConfig):
+    """
+    Parameters for user-defined additional launch files.
+
+    These launch files may be specified by absolute path or relative path + package.
+
+    Launch arguments may provided as a {str: Any} dict of key value pairs.
+    """
+
+    PACKAGE = 'package'
+    PATH = 'path'
+    ARGS = 'args'
+
+    TEMPALTE = {
+        PACKAGE: PACKAGE,
+        PATH: PATH,
+        ARGS: ARGS,
+    }
+
+    KEYS = flip_dict(TEMPALTE)
+
+    DEFAULTS = {
+        PATH: '',
+        PACKAGE: None,
+        ARGS: {}
+    }
+
+    def __init__(
+        self,
+        config: dict = {},
+        path: str = DEFAULTS[PATH],
+        package: str = DEFAULTS[PACKAGE],
+        args: dict = DEFAULTS[ARGS],
+    ):
+        self._args = {}
+        self._package = None
+        self._path = ''
+
+        setters = {
+            self.KEYS[self.PACKAGE]: LaunchConfig.package,
+            self.KEYS[self.PATH]: LaunchConfig.path,
+            self.KEYS[self.ARGS]: LaunchConfig.args,
+        }
+
+        super().__init__(setters, config)
+
+        self.path = path
+        self.package = package
+        self.args = args
+
+    def from_dict(self, d: dict) -> None:
+        self.path = d.get('path', '')
+        self.package = d.get('package', None)
+        self.args = d.get('args', {})
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+    @path.setter
+    def path(self, path: str) -> None:
+        assert isinstance(path, str), f'Path {path} must be a string'
+        self._path = path
+
+    @property
+    def package(self) -> str:
+        return self._package
+
+    @package.setter
+    def package(self, package: str) -> None:
+        assert package is None or isinstance(package, str), f'Package {package} must be a string'
+        self._package = package
+
+    @property
+    def args(self) -> dict:
+        return self._args
+
+    @args.setter
+    def args(self, args: dict) -> None:
+        if args is None:
+            args = {}
+
+        assert isinstance(args, dict), 'Arguments must be of type "dict"'
+        self._args = {}
+        for arg in args:
+            assert isinstance(arg, str), f'Argument key {arg} must be of type "str"'
+            self._args[arg] = args[arg]


### PR DESCRIPTION
Allow multiple launch files to be listed in platform.extras.launch, add launch arguments field to allow passing args

See RPSW-2815
See https://github.com/clearpathrobotics/clearpath_robot/pull/271