### PR TITLE
Change exception when middleware config file doesn't exist

### DIFF
--- a/clearpath_config/platform/extras.py
+++ b/clearpath_config/platform/extras.py
@@ -281,6 +281,9 @@ class ExtrasConfig(BaseConfig):
 
     @launch.setter
     def launch(self, value: List[LaunchConfig] | List[dict] | LaunchConfig | dict) -> None:
+        if value is None:
+            value = []
+
         # Previously only a single launch file was supported
         # For compatibility, transform the old format to the new one, but print a deprecation
         # notice, as this translation layer may be removed in the future

--- a/clearpath_config/system/middleware.py
+++ b/clearpath_config/system/middleware.py
@@ -173,15 +173,19 @@ class MiddlewareConfig(BaseConfig):
 
     @profile.setter
     def profile(self, value: str) -> None:
+        """
+        Set the path to the middleware profile file.
+
+        :raises FileNotFoundError: if the specified path does not exist
+        """
         # Check Type
         assert isinstance(value, str), (
             f'Middleware profile {value} is invalid, must be a string'
         )
         # Valid file
         if value != self.DEFAULTS[self.PROFILE]:
-            assert os.path.exists(value), (
-                f'Middleware profile path {value} does not exist'
-            )
+            if not os.path.exists(value):
+                raise FileNotFoundError(f'Middleware profile path {value} does not exist')
         self._profile = value
         return
 


### PR DESCRIPTION
Raise a `FileNotFound` exception instead of an assertion error if the middleware config path doesn't exist; this makes it easier to catch those exceptions in CI tests.

Fix a bug where setting the extra launch to None raises an unintended exception