### PR TITLE
Replace `assert` with `raise` + relevant Exception

### DIFF
--- a/clearpath_config/clearpath_config.py
+++ b/clearpath_config/clearpath_config.py
@@ -144,7 +144,8 @@ class ClearpathConfig(BaseConfig):
 
     @version.setter
     def version(self, v: int) -> None:
-        assert isinstance(v, int), 'version must be of type "int"'
+        if not isinstance(v, int):
+            raise ValueError(f'Version {v} must be of type "int" not "{type(v)}"')
         self._version = v
         # Add propagators here
 

--- a/clearpath_config/common/types/accessory.py
+++ b/clearpath_config/common/types/accessory.py
@@ -112,24 +112,32 @@ class Accessory():
     @staticmethod
     def assert_valid_link(link: str) -> None:
         # Link name must be a string
-        assert isinstance(link, str), f'Link name "{link}" must be string'
+        if not isinstance(link, str):
+            raise TypeError(f'Link name "{link}" must be string')
         # Link name must not be empty
-        assert link, f'Link name "{link}" must not be empty'
+        if not link:
+            raise ValueError(f'Link name "{link}" must not be empty')
         # Link name must not have spaces
-        assert ' ' not in link, f'Link name "{link}" must no have spaces'
+        if ' ' in link:
+            raise ValueError(f'Link name "{link}" must no have spaces')
         # Link name must not start with a digit
-        assert not link[0].isdigit(), f'Link name "{link} must not start with a digit'
+        if link[0].isdigit():
+            raise ValueError(f'Link name "{link} must not start with a digit')
 
     @staticmethod
     def assert_valid_triplet(tri: List[float], msg: str = None) -> None:
         if msg is None:
             msg = 'Triplet must be a list of three float values'
         # Triplet must be a list
-        assert isinstance(tri, list), msg
+        if not isinstance(tri, list):
+            raise TypeError(msg)
         # Triplet must have a length of 3
-        assert len(tri) == 3, msg
+        if len(tri) != 3:
+            raise ValueError(msg)
         # Triplet must be all floats
-        assert all([isinstance(i, float) for i in tri])  # noqa:C419
+        for i in tri:
+            if not isinstance(i, float):
+                raise TypeError(msg)
 
     @staticmethod
     def assert_is_supported():
@@ -203,6 +211,8 @@ class IndexedAccessory(Accessory):
         return self.idx
 
     def set_idx(self, idx: int) -> None:
-        assert isinstance(idx, int), 'Index must be an integer'
-        assert idx >= 0, 'Index must be a positive integer'
+        if not isinstance(idx, int):
+            raise TypeError(f'Index {idx} must be an integer')
+        if idx < 0:
+            raise ValueError(f'Index {idx} must be a positive integer')
         self.name = self.get_name_from_idx(idx)

--- a/clearpath_config/common/types/config.py
+++ b/clearpath_config/common/types/config.py
@@ -94,7 +94,7 @@ class BaseConfig:
         if value is None:
             return
         if not isinstance(value, dict):
-           raise TypeError(f'Config must be of type "dict", not "{type(value)}"')
+            raise TypeError(f'Config must be of type "dict", not "{type(value)}"')
         if self._parent_key is not None and self._parent_key not in value:
             value = {self._parent_key: value}
         value = unflatten_dict(value)

--- a/clearpath_config/common/types/config.py
+++ b/clearpath_config/common/types/config.py
@@ -72,13 +72,13 @@ class BaseConfig:
 
     @template.setter
     def template(self, value: dict) -> None:
-        assert isinstance(value, dict), 'template must be of type "dict"'
+        if not isinstance(value, dict):
+            raise TypeError(f'Template must be of type "dict" not "{type(value)}"')
         # Check that template has all properties
         flat_template = flatten_dict(d=value, dlim=BaseConfig.DLIM)
-        for _, val in flat_template.items():
-            assert isinstance(val, property), (
-                'All entries in template must be properties'
-            )
+        for key, val in flat_template.items():
+            if not isinstance(val, property):
+                raise ValueError(f'Template value at {key} must be a property')
         self._template = value
 
     @property
@@ -93,7 +93,8 @@ class BaseConfig:
     def config(self, value: dict) -> None:
         if value is None:
             return
-        assert isinstance(value, dict), 'config must be of type "dict"'
+        if not isinstance(value, dict):
+           raise TypeError(f'Config must be of type "dict", not "{type(value)}"')
         if self._parent_key is not None and self._parent_key not in value:
             value = {self._parent_key: value}
         value = unflatten_dict(value)
@@ -140,4 +141,5 @@ class BaseConfig:
         elif isinstance(namespace, str):
             BaseConfig._NAMESPACE = Namespace(namespace)
         else:
-            assert isinstance(namespace, str) or isinstance(namespace, Namespace), 'Namespace must be of type "str" or "Namespace"'  # noqa:E501
+            if not (isinstance(namespace, str) or isinstance(namespace, Namespace)):
+                raise TypeError('Namespace {namespace} must be of type "str" or "Namespace"')

--- a/clearpath_config/common/types/discovery.py
+++ b/clearpath_config/common/types/discovery.py
@@ -60,7 +60,7 @@ class Discovery:
 
     @classmethod
     def assert_valid(cls, mode: str) -> None:
-        assert cls.is_valid(mode), ('\n'.join([
-            f'Discovery mode "{mode}" not supported.'
-            f'Discovery mode must be one of: "{cls.ALL_SUPPORTED}"'
-        ]))
+        if not cls.is_valid(mode):
+            raise ValueError(
+                f'Discovery mode {mode} is not supported; must be one of {cls.ALL_SUPPORTED}'
+            )

--- a/clearpath_config/common/types/domain_id.py
+++ b/clearpath_config/common/types/domain_id.py
@@ -27,6 +27,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 class DomainID:
 
+    MIN_DOMAIN = 0
+    MAX_DOMAIN = 101
+
     def __init__(self, _id: int = 0) -> None:
         self.assert_valid(_id)
         self.id = _id
@@ -47,11 +50,11 @@ class DomainID:
     @staticmethod
     def assert_valid(_id: int) -> None:
         # Check Type
-        assert isinstance(_id, int), (
-            'Domain ID must be an integer'
-        )
+        if not isinstance(_id, int):
+            raise TypeError(f'Domain ID {id} must be an integer')
         # 0 - 101 Range
-        assert 0 <= _id <= 101, (
-            'Domain ID must be in range 0 - 101'
-        )
+        if _id < DomainID.MIN_DOMAIN or id > DomainID.MAX_DOMAIN:
+            raise ValueError(
+                f'Domain ID {id} must be in range {DomainID.MIN_DOMAIN} - {DomainID.MAX_DOMAIN}'
+            )
         return

--- a/clearpath_config/common/types/domain_id.py
+++ b/clearpath_config/common/types/domain_id.py
@@ -51,10 +51,10 @@ class DomainID:
     def assert_valid(_id: int) -> None:
         # Check Type
         if not isinstance(_id, int):
-            raise TypeError(f'Domain ID {id} must be an integer')
+            raise TypeError(f'Domain ID {_id} must be an integer')
         # 0 - 101 Range
-        if _id < DomainID.MIN_DOMAIN or id > DomainID.MAX_DOMAIN:
+        if _id < DomainID.MIN_DOMAIN or _id > DomainID.MAX_DOMAIN:
             raise ValueError(
-                f'Domain ID {id} must be in range {DomainID.MIN_DOMAIN} - {DomainID.MAX_DOMAIN}'
+                f'Domain ID {_id} must be in range {DomainID.MIN_DOMAIN} - {DomainID.MAX_DOMAIN}'
             )
         return

--- a/clearpath_config/common/types/file.py
+++ b/clearpath_config/common/types/file.py
@@ -34,9 +34,11 @@ class File:
 
     def __init__(self, path: str, creatable=False, exists=False, make_abs=True) -> None:
         if creatable:
-            assert File.is_creatable(path)
+            if not File.is_creatable(path):
+                raise PermissionError(f'File path {path} cannot be created')
         if exists:
-            assert File.is_exists(path)
+            if not File.is_exists(path):
+                raise FileNotFoundError(f'File {path} does not exist')
         self.path = File.clean(path, make_abs)
 
     def __str__(self) -> str:

--- a/clearpath_config/common/types/hostname.py
+++ b/clearpath_config/common/types/hostname.py
@@ -64,26 +64,20 @@ class Hostname:
 
     @staticmethod
     def assert_valid(hostname: str):
-        assert isinstance(hostname, str), (
-            'Hostname "%s" must be of type "str"' % hostname
-        )
+        if not isinstance(hostname, str):
+            raise TypeError(f'Hostname {hostname} most be of type "str"')
         # Min 1 ASCII Characters
-        assert len(hostname) > 0, (
-            'Hostname "%s" is blank.' % hostname
-        )
+        if len(hostname) == 0:
+            raise ValueError('Hostname cannot be blank')
         # Max 253 ASCII Characters
-        assert len(hostname) < 254, (
-            'Hostname "%s" exceeds 253 ASCII character limit.' % hostname
-        )
+        if len(hostname) >= 254:
+            raise ValueError(f'Hostname "{hostname}" exceeds 253 ASCII character limit.')
         # No Trailing Dots
-        assert hostname[-1] != '.', (
-            'Hostname "%s" should not end with a "." period.' % hostname
-        )
+        if hostname.endswith('.'):
+            raise ValueError(f'Hostname "{hostname}" cannot end with a "." (period).')
         # Only [A-Z][0-9] and '-' Allowed
         allowed = re.compile(r'(?!-)[A-Z\d-]{1,63}(?<!-)$', re.IGNORECASE)
-        assert all(allowed.match(x) for x in hostname.split('.')), (
-            'Hostname "%s" cannot contain characters other than %s.' % (
-                hostname,
-                '[A-Z][0-9] and hypens ('-')'
+        if not all(allowed.match(x) for x in hostname.split('.')):
+            raise ValueError(
+                f'Hostname {hostname} cannot contain characters other than [A-Z][a-z][0-9] and -'
             )
-        )

--- a/clearpath_config/common/types/ip.py
+++ b/clearpath_config/common/types/ip.py
@@ -66,13 +66,17 @@ class IP:
     @staticmethod
     def assert_valid(ip: str) -> None:
         # Must be String
-        assert isinstance(ip, str), f'IP "{ip}" must be of type "str"'
+        if not isinstance(ip, str):
+            raise TypeError(f'IP "{ip}" must be of type "str"')
         # Must have Four Fields Delimited by '.'
         fields = ip.split('.')
-        assert len(fields) == 4, f'IP "{ip}" must have 4 fields'
+        if len(fields) != 4:
+            raise ValueError(f'IP "{ip}" must have 4 fields')
         for field in fields:
             # Fields Must be Integer
-            assert field.isdecimal(), f'IP "{ip}" fields must be integers'
+            if not field.isdecimal():
+                raise ValueError(f'IP "{ip}" fields must be integers')
             # Fields Must be 8-Bits Wide
             field_int = int(field)
-            assert 0 <= field_int < 256, f'IP "{ip} fields must be in range 0 to 255'
+            if field_int < 0 or field_int > 255:
+                raise ValueError(f'IP {ip} fields must be in range 0 to 255')

--- a/clearpath_config/common/types/list.py
+++ b/clearpath_config/common/types/list.py
@@ -86,30 +86,22 @@ class ListConfig(Generic[T, U]):
             self,
             obj: T,
             ) -> None:
-        assert isinstance(obj, self.__type_T), (
-            'Object must be of type %s' % (
-                self.__type_T.__name__
-            )
-        )
-        assert self.find(obj) is None, (
-            'Object with uid %s is not unique.' % (
-                self.__uid(obj)
-            )
-        )
+        if not isinstance(obj, self.__type_T):
+            raise TypeError(f'Object must be of type "{self.__type_T.__name__}"')
+        if self.find(obj) is not None:
+            raise ValueError(f'Object with uid {self.__uid(obj)} is not unique.')
         self.__list.append(obj)
 
     def replace(
             self,
             obj: T,
             ) -> None:
-        assert isinstance(obj, self.__type_T), (
-            'Object must be of type %s' % T
-        )
-        assert self.find(obj) is not None, (
-            'Object with uid %s cannot be replaced. Does not exist.' % (
-                self.__uid(obj)
+        if not isinstance(obj, self.__type_T):
+            raise TypeError(f'Object must be of type {T}')
+        if self.find(obj) is None:
+            raise IndexError(
+                f'Object with uid {self.__uid(obj)} cannot be replaced. Does not exist.'
             )
-        )
         self.__list[self.find(obj)] = obj
 
     def remove(
@@ -183,8 +175,10 @@ class ListConfig(Generic[T, U]):
 class OrderedListConfig(Generic[T]):
 
     def __init__(self, obj_type: type, start_idx: int = 0) -> None:
-        assert callable(getattr(obj_type, 'get_idx')), f'Type {type} does not have ".get_idx()"'
-        assert callable(getattr(obj_type, 'set_idx')), f'Type {type} does not have ".set_idx(i)"'
+        if not callable(getattr(obj_type, 'get_idx')):
+            raise NotImplementedError(f'Type {type} does not have ".get_idx()"')
+        if not callable(getattr(obj_type, 'set_idx')):
+            raise NotImplementedError(f'Type {type} does not have ".set_idx(i)"')
 
         self.start_idx = start_idx
         self.__type_T: type = obj_type
@@ -222,9 +216,8 @@ class OrderedListConfig(Generic[T]):
             self,
             obj: T
             ) -> None:
-        assert isinstance(obj, self.__type_T), (
-            'Object must be of type %s' % T
-        )
+        if not isinstance(obj, self.__type_T):
+            raise TypeError(f'Object must be of type {T}')
         self.__list.append(obj)
         self.update()
 
@@ -233,9 +226,8 @@ class OrderedListConfig(Generic[T]):
             obj: T,
             ) -> None:
         idx = self.find(obj)
-        assert idx is not None, (
-            'Object not found. Cannot be replaced'
-        )
+        if idx is None:
+            raise IndexError(f'Object {obj} not found. Cannot be replaced')
         self.__list[idx - self.start_idx] = obj
         self.update()
 

--- a/clearpath_config/common/types/namespace.py
+++ b/clearpath_config/common/types/namespace.py
@@ -79,39 +79,35 @@ class Namespace:
     @staticmethod
     def assert_valid(name: str) -> None:
         # Empty
-        assert name != '', (
-            'Namespace cannot be empty'
-        )
+        if not name:
+            raise ValueError('Namespace cannot be empty')
         # Allowed characters
         allowed = re.compile('[a-z|0-9|_|/|~]', re.IGNORECASE)
-        assert all(allowed.match(c) for c in name), ('\n'.join([
-            'Namespace can only contain:',
-            ' - [A-Z|a-z|0-9]',
-            ' - underscores (_)',
-            ' - forward slahes (/)',
-            ' - leading tilde (~)'
-        ]))
+        if not all(allowed.match(c) for c in name):
+            raise ValueError(
+f"""Namespace "{name}" can only contain:
+ - [A-Z|a-z|0-9],
+ - underscores (_),
+ - forward slahes (/),
+ - leading tilde (~)
+"""
+            )
         # Leading Tilde (~)
         if name[0] == '~':
-            assert name[1] == '/', (
-                'Namespace starting with (~) must be followed by (/)'
-            )
+            if name[1] != '/':
+                raise ValueError('Namespace starting with "~" must be followed by "/"')
         # Leading Digit
-        assert not str(name[0]).isdigit(), (
-            'Namespace may not start with a digit'
-        )
+        if str(name[0]).isdigit():
+            raise ValueError(f'Namespace "{name}" may not start with a digit')
         # Ending Forward Slash (/)
-        assert len(name) == 1 or name[-1] != '/', (
-            'Namespace may not end with a forward slash (/)'
-        )
+        if len(name) != 1 and name[-1] == '/':
+            raise ValueError(f'Namespace "{name}" may not end with a forward slash (/)')
         # Repeated Forward Slash (/)
-        assert '//' not in name, (
-            'Namespace may not contain repeated forward slashes (/)'
-        )
+        if '//' in name:
+            raise ValueError(f'Namespace "{name}" may not contain repeated forward slashes (/)')
         # Repeated Underscores (/)
-        assert '__' not in name, (
-            'Namespace may not contain repeated underscores (_)'
-        )
+        if '__' in name:
+            raise ValueError(f'Namespace "{name}" may not contain repeated underscores (_)')
 
     @staticmethod
     def clean(name: str) -> str:

--- a/clearpath_config/common/types/namespace.py
+++ b/clearpath_config/common/types/namespace.py
@@ -84,14 +84,11 @@ class Namespace:
         # Allowed characters
         allowed = re.compile('[a-z|0-9|_|/|~]', re.IGNORECASE)
         if not all(allowed.match(c) for c in name):
-            raise ValueError(
-f"""Namespace "{name}" can only contain:
+            raise ValueError(f"""Namespace "{name}" can only contain:
  - [A-Z|a-z|0-9],
  - underscores (_),
  - forward slahes (/),
- - leading tilde (~)
-"""
-            )
+ - leading tilde (~)""")
         # Leading Tilde (~)
         if name[0] == '~':
             if name[1] != '/':

--- a/clearpath_config/common/types/port.py
+++ b/clearpath_config/common/types/port.py
@@ -30,6 +30,9 @@
 # - TCP Port
 class Port:
 
+    MIN_PORT = 0
+    MAX_PORT = 65535
+
     def __init__(self, port: int) -> None:
         self.assert_valid(port)
         self.port = int(port)
@@ -56,14 +59,16 @@ class Port:
         except Exception:
             return False
         # Must be in Range
-        return 0 <= port < 65536
+        return Port.MIN_PORT <= port <= Port.MAX_PORT
 
     @staticmethod
     def assert_valid(port: int) -> None:
         # Must be an integer
         try:
             port = int(port)
-        except ValueError as e:
-            raise AssertionError(e.args)
+        except ValueError:
+            raise TypeError(f'Port {port} must be an integer')
         # Must be in Range
-        assert 0 <= port < 65536, f'Port "{port}" must be between 0 and 65535'
+        if port < Port.MIN_PORT or port > Port.MAX_PORT:
+            raise ValueError(
+                f'Port "{port}" must be in range {Port.MIN_PORT} to {Port.MAX_PORT}')

--- a/clearpath_config/common/types/rmw_implementation.py
+++ b/clearpath_config/common/types/rmw_implementation.py
@@ -61,7 +61,7 @@ class RMWImplementation:
 
     @classmethod
     def assert_valid(cls, rmw: str) -> None:
-        assert cls.is_valid(rmw), ('\n'.join([
-            'RMW "%s" not supported.' % rmw,
-            'RMW must be one of: "%s"' % cls.ALL_SUPPORTED
-        ]))
+        if not cls.is_valid(rmw):
+            raise ValueError(
+                f'RMW "{rmw}" is not supported. Must be one of {cls.ALL_SUPPORTED}'
+            )

--- a/clearpath_config/common/types/serial_number.py
+++ b/clearpath_config/common/types/serial_number.py
@@ -54,7 +54,9 @@ class SerialNumber:
             raise TypeError(f'Serial Number "{sn}" must be string')
         sn_tokens = sn.lower().strip().split('-')
         if len(sn_tokens) <= 0 or len(sn_tokens) >= 4:
-            raise ValueError(f'Serial number {sn}" must be delimited by hypens "-" and have 2 or 3 fields (e.g. cpr-a300-00001 or a300-00001), or 1 (generic) field')
+            raise ValueError(
+                f'Serial number {sn}" must be delimited by hypens "-" and have 2 or 3 fields (e.g. cpr-a300-00001 or a300-00001), or 1 (generic) field'  # noqa: E501
+            )
         # Remove CPR Prefix
         if len(sn_tokens) == 3:
             if sn_tokens[0] != 'cpr':

--- a/clearpath_config/common/types/serial_number.py
+++ b/clearpath_config/common/types/serial_number.py
@@ -42,51 +42,50 @@ class SerialNumber:
         return self.get_serial()
 
     def from_dict(self, config: dict) -> None:
-        assert isinstance(config, dict), 'Config must be of type "dict"'
-        assert self.SERIAL_NUMBER in config, f'Key "{self.SERIAL_NUMBER}" must be in config'
+        if not isinstance(config, dict):
+            raise TypeError('Config must be of type "dict"')
+        if self.SERIAL_NUMBER not in config:
+            raise ValueError(f'Key "{self.SERIAL_NUMBER}" must be in config')
         self.model, self.unit = SerialNumber.parse(config[self.SERIAL_NUMBER])
 
     @staticmethod
     def parse(sn: str) -> tuple:
-        assert isinstance(sn, str), 'Serial Number must be string'
-        sn = sn.lower().strip().split('-')
-        assert (
-            0 < len(sn) < 4
-        ), 'Serial Number must be delimited by hyphens ('-') \
-            and only have 3 (cpr-j100-0001) entries, \
-            2 (j100-0001) entries, \
-            or 1 (generic) entry'
+        if not isinstance(sn, str):
+            raise TypeError(f'Serial Number "{sn}" must be string')
+        sn_tokens = sn.lower().strip().split('-')
+        if len(sn_tokens) <= 0 or len(sn_tokens) >= 4:
+            raise ValueError(f'Serial number {sn}" must be delimited by hypens "-" and have 2 or 3 fields (e.g. cpr-a300-00001 or a300-00001), or 1 (generic) field')
         # Remove CPR Prefix
-        if len(sn) == 3:
-            assert (
-                sn[0] == 'cpr'
-            ), 'Serial Number with three fields (%s) must start with cpr' % (
-                'cpr-j100-0001',
-            )
-            sn = sn[1:]
+        if len(sn_tokens) == 3:
+            if sn_tokens[0] != 'cpr':
+                raise ValueError(
+                    f'Serial number with 3 fields must start with "cpr" not "{sn_tokens[0]}"'
+                )
+            sn_tokens = sn_tokens[1:]
         # Silently replace A201 prefix with A200
         # Mechanically both are effectively identical, and re-use the same options & payloads
-        if sn[0] == 'a201':
-            sn[0] = 'a200'
+        if sn_tokens[0] == 'a201':
+            sn_tokens[0] = 'a200'
         # Match to Robot
-        assert sn[0] in Platform.ALL, (
-            'Serial Number model entry must match one of %s' % Platform.ALL
-        )
+        if sn_tokens[0] not in Platform.ALL:
+            raise ValueError(
+                f'Serial number model entry {sn_tokens[0]} must be one of {Platform.ALL}'
+            )
 
         # Verify that the platform is well-supported and not deprecated
-        Platform.assert_is_supported(sn[0])
-        Platform.notify_if_deprecated(sn[0])
+        Platform.assert_is_supported(sn_tokens[0])
+        Platform.notify_if_deprecated(sn_tokens[0])
 
         # Generic Robot
-        if sn[0] == Platform.GENERIC:
+        if sn_tokens[0] == Platform.GENERIC:
             if len(sn) > 1:
-                return (sn[0], sn[1])
+                return (sn_tokens[0], sn[1])
             else:
-                return (sn[0], 'xxxx')
+                return (sn_tokens[0], 'xxxx')
         # Check Number
-        assert sn[1].isdecimal(), (
-            'Serial Number unit entry must be an integer value')
-        return (sn[0], sn[1])
+        if not sn_tokens[1].isdecimal():
+            raise ValueError(f'Serial number unit entry "{sn_tokens[1]}" must be an integer')
+        return (sn_tokens[0], sn_tokens[1])
 
     def get_model(self) -> str:
         return self.model

--- a/clearpath_config/common/types/username.py
+++ b/clearpath_config/common/types/username.py
@@ -79,10 +79,8 @@ class Username:
         # Regex Convention
         allowed = re.compile(r'[-a-z0-9]')
         if not all(allowed.match(c) for c in username):
-            raise ValueError(
-f"""Username "{username} cannot contain characters other than:
+            raise ValueError(f"""Username "{username} cannot contain characters other than:
  - letters [a-z]
  - digits [0-9]
  - hyphen "-"
- """
-            )
+ """)

--- a/clearpath_config/common/types/username.py
+++ b/clearpath_config/common/types/username.py
@@ -68,7 +68,7 @@ class Username:
         if not isinstance(username, str):
             raise TypeError(f'Username {username} must be of type "str"')
         # Max 255 Characters
-        if len(username >= 256):
+        if len(username) >= 256:
             raise ValueError(f'Username {username} exceeds 255 ASCII character limit')
         # Username cannot start with digit
         if username[0].isdigit():

--- a/clearpath_config/common/types/username.py
+++ b/clearpath_config/common/types/username.py
@@ -65,21 +65,24 @@ class Username:
     @staticmethod
     def assert_valid(username: str):
         # Check Type
-        assert isinstance(username, str), (
-            'Username "%s" must of type "str"' % username
-        )
+        if not isinstance(username, str):
+            raise TypeError(f'Username {username} must be of type "str"')
         # Max 255 Characters
-        assert len(username) < 256, (
-            'Username "%s" exceeds 255 ASCII character limit.' % username
-        )
+        if len(username >= 256):
+            raise ValueError(f'Username {username} exceeds 255 ASCII character limit')
+        # Username cannot start with digit
+        if username[0].isdigit():
+            raise ValueError(f'Username {username} cannot start with a digit')
+        # Username cannot start with hyphen
+        if username[0] == '-':
+            raise ValueError(f'Username {username} cannot start with a hyphen')
         # Regex Convention
-        allowed = re.compile(r'[-a-z0-9_]')
-        assert all(allowed.match(c) for c in username), (
-            'Username "%s" cannot contain characters other than: %s, %s, %s, %s' % (
-                username,
-                'lowercase letters',
-                'digits',
-                'underscores',
-                'dashes'
+        allowed = re.compile(r'[-a-z0-9]')
+        if not all(allowed.match(c) for c in username):
+            raise ValueError(
+f"""Username "{username} cannot contain characters other than:
+ - letters [a-z]
+ - digits [0-9]
+ - hyphen "-"
+ """
             )
-        )

--- a/clearpath_config/common/utils/dictionary.py
+++ b/clearpath_config/common/utils/dictionary.py
@@ -94,7 +94,10 @@ def flip_dict(d: MutableMapping, parent_key: str = '', dlim: str = '.'):
     flat = flatten_dict(d, parent_key, dlim)
     flip = {}
     for k, v in flat.items():
-        assert isinstance(v, str), 'Flipping dictionary requires all values to be of type "str"'
+        if not isinstance(v, str):
+            raise TypeError(
+                'Flipping dictionary requires all values to be of type "str". Invalid key {v}'
+            )
         flip[v] = k
     return flip
 

--- a/clearpath_config/common/utils/yaml.py
+++ b/clearpath_config/common/utils/yaml.py
@@ -28,6 +28,8 @@
 import os
 
 import yaml
+from yaml.constructor import ConstructorError
+from yaml.scanner import ScannerError
 
 
 # Get Valid Path
@@ -50,24 +52,19 @@ def find_valid_path(path, cwd=None):
 def read_yaml(path: str) -> dict:
     orig = path
     # Check YAML Path
-    try:
-        path = find_valid_path(path, os.getcwd())
-        assert path, f'YAML file "{orig}" could not be found'
-    except FileNotFoundError:
-        raise AssertionError(
-            f'YAML file "{orig}" could not be found')
+    path = find_valid_path(path, os.getcwd())
+    if not path:
+        raise FileNotFoundError(f'YAML file {orig} could not be found')
     # Check YAML can be Opened
     try:
         config = yaml.load(open(path), Loader=yaml.SafeLoader)
-    except yaml.scanner.ScannerError:
-        raise AssertionError(
-            f'YAML file "{orig}" is not well formed')
-    except yaml.constructor.ConstructorError:
-        raise AssertionError(
-            f'YAML file "{orig}" is attempting to create unsafe objects')
+    except ScannerError:
+        raise ScannerError(f'YAML file {orig} is not well-formed')
+    except ConstructorError:
+        raise ConstructorError(f'YAML file "{orig}" is attempting to create unsafe objects')
     # Check contents are a Dictionary
-    assert isinstance(config, dict), (
-        f'YAML file "{orig}" is not a dictionary')
+    if not isinstance(config, dict):
+        raise TypeError(f'YAML file "{orig}" is not a dictionary')
     return config
 
 

--- a/clearpath_config/links/links.py
+++ b/clearpath_config/links/links.py
@@ -56,7 +56,7 @@ class Link():
 
     @classmethod
     def assert_type(cls, _type: str) -> None:
-        if not _type in cls.TYPE:
+        if _type not in cls.TYPE:
             raise TypeError(f'Sensor type "{_type}" must be one of "{cls.TYPE.keys()}')
 
     def __new__(cls, _type: str, name: str) -> BaseLink:

--- a/clearpath_config/links/links.py
+++ b/clearpath_config/links/links.py
@@ -56,7 +56,8 @@ class Link():
 
     @classmethod
     def assert_type(cls, _type: str) -> None:
-        assert _type in cls.TYPE, f'Sensor type "{_type}" must be one of "{cls.TYPE.keys()}'
+        if not _type in cls.TYPE:
+            raise TypeError(f'Sensor type "{_type}" must be one of "{cls.TYPE.keys()}')
 
     def __new__(cls, _type: str, name: str) -> BaseLink:
         cls.assert_type(_type)
@@ -146,7 +147,9 @@ class LinksConfig(BaseConfig):
     @frame.setter
     def frame(self, value: List[dict] | LinkListConfig) -> None:
         if isinstance(value, list):
-            assert all([isinstance(i, dict) for i in value]), 'Links must be of type "dict"'  # noqa:C419, E501
+            for i in value:
+                if not isinstance(i, dict):
+                    raise TypeError(f'Frame {i} must be of type "dict"')
             links = LinkListConfig()
             link_list = []
             for d in value:
@@ -156,7 +159,8 @@ class LinksConfig(BaseConfig):
             links.set_all(link_list)
             self._frame = links
         else:
-            assert isinstance(value, list), 'Links must be of type "dict"'
+            if not isinstance(value, list):
+                raise TypeError('Frames must be of type "list[dict]"')
 
     @property
     def box(self) -> LinkListConfig:
@@ -169,7 +173,9 @@ class LinksConfig(BaseConfig):
     @box.setter
     def box(self, value: List[dict] | LinkListConfig) -> None:
         if isinstance(value, list):
-            assert all([isinstance(i, dict) for i in value]), 'Links must be of type "dict"'  # noqa:C419, E501
+            for i in value:
+                if not isinstance(i, dict):
+                    raise TypeError(f'Box {i} must be of type "dict"')
             links = LinkListConfig()
             link_list = []
             for d in value:
@@ -179,7 +185,8 @@ class LinksConfig(BaseConfig):
             links.set_all(link_list)
             self._box = links
         else:
-            assert isinstance(value, list), 'Links must be of type "dict"'
+            if not isinstance(value, list):
+                raise TypeError('Boxes must be of type "list[dict]"')
 
     @property
     def cylinder(self) -> LinkListConfig:
@@ -192,7 +199,9 @@ class LinksConfig(BaseConfig):
     @cylinder.setter
     def cylinder(self, value: List[dict] | LinkListConfig) -> None:
         if isinstance(value, list):
-            assert all([isinstance(i, dict) for i in value]), 'Links must be of type "dict"'  # noqa:C419, E501
+            for i in value:
+                if not isinstance(i, dict):
+                    raise TypeError(f'Cylinder {i} must be of type "dict"')
             links = LinkListConfig()
             link_list = []
             for d in value:
@@ -202,7 +211,8 @@ class LinksConfig(BaseConfig):
             links.set_all(link_list)
             self._cylinder = links
         else:
-            assert isinstance(value, list), 'Links must be of type "dict"'
+            if not isinstance(value, list):
+                raise TypeError('Cylinders must be of type "list[dict]"')
 
     @property
     def mesh(self) -> LinkListConfig:
@@ -215,7 +225,9 @@ class LinksConfig(BaseConfig):
     @mesh.setter
     def mesh(self, value: List[dict] | LinkListConfig) -> None:
         if isinstance(value, list):
-            assert all([isinstance(i, dict) for i in value]), 'Links must be of type "dict"'  # noqa:C419, E501
+            for i in value:
+                if not isinstance(i, dict):
+                    raise TypeError(f'Mesh {i} must be of type "dict"')
             links = LinkListConfig()
             link_list = []
             for d in value:
@@ -225,7 +237,8 @@ class LinksConfig(BaseConfig):
             links.set_all(link_list)
             self._mesh = links
         else:
-            assert isinstance(value, list), 'Links must be of type "dict"'
+            if not isinstance(value, list):
+                raise TypeError('Meshes must be of type "list[dict]"')
 
     @property
     def sphere(self) -> LinkListConfig:
@@ -238,7 +251,9 @@ class LinksConfig(BaseConfig):
     @sphere.setter
     def sphere(self, value: List[dict] | LinkListConfig) -> None:
         if isinstance(value, list):
-            assert all([isinstance(i, dict) for i in value]), 'Links must be of type "dict"'  # noqa:C419, E501
+            for i in value:
+                if not isinstance(i, dict):
+                    raise TypeError(f'Sphere {i} must be of type "dict"')
             links = LinkListConfig()
             link_list = []
             for d in value:
@@ -248,7 +263,8 @@ class LinksConfig(BaseConfig):
             links.set_all(link_list)
             self._sphere = links
         else:
-            assert isinstance(value, list), 'Links must be of type "dict"'
+            if not isinstance(value, list):
+                raise TypeError('Spheres must be of type "list[dict]"')
 
     def get_all_links(self) -> List[BaseLink]:
         links = []
@@ -277,9 +293,8 @@ class LinksConfig(BaseConfig):
             offset_xyz: List[float] = BaseLink.XYZ,
             offset_rpy: List[float] = BaseLink.RPY
             ) -> None:
-        assert frame or name, (
-            'Frame object or name must be passed'
-        )
+        if not (frame or name):
+            raise ValueError('Frame object or name must be passed')
         if not frame and name:
             frame = Frame(
                 name=name,
@@ -332,9 +347,8 @@ class LinksConfig(BaseConfig):
             offset_xyz: List[float] = BaseLink.XYZ,
             offset_rpy: List[float] = BaseLink.RPY
             ) -> None:
-        assert box or name, (
-            'Box object or name must be passed'
-        )
+        if not (box or name):
+            raise ValueError('Box object or name must be passed')
         if not box and name:
             box = Box(
                 name=name,
@@ -382,9 +396,8 @@ class LinksConfig(BaseConfig):
             offset_xyz: List[float] = BaseLink.XYZ,
             offset_rpy: List[float] = BaseLink.RPY
             ) -> None:
-        assert cylinder or name, (
-            'Cylinder object or name must be passed'
-        )
+        if not (cylinder or name):
+            raise ValueError('Cylinder object or name must be passed')
         if not cylinder and name:
             cylinder = Cylinder(
                 name=name,
@@ -432,9 +445,8 @@ class LinksConfig(BaseConfig):
             offset_xyz: List[float] = BaseLink.XYZ,
             offset_rpy: List[float] = BaseLink.RPY
             ) -> None:
-        assert sphere or name, (
-            'Sphere object or name must be passed'
-        )
+        if not (sphere or name):
+            raise ValueError('Sphere object or name must be passed')
         if not sphere and name:
             sphere = Sphere(
                 name=name,
@@ -481,9 +493,8 @@ class LinksConfig(BaseConfig):
             offset_xyz: List[float] = BaseLink.XYZ,
             offset_rpy: List[float] = BaseLink.RPY
             ) -> None:
-        assert mesh or name, (
-            'Mesh object or name must be passed'
-        )
+        if not (mesh or name):
+            raise ValueError('Mesh object or name must be passed')
         if not mesh and name:
             mesh = Mesh(
                 name=name,

--- a/clearpath_config/links/types/box.py
+++ b/clearpath_config/links/types/box.py
@@ -67,9 +67,11 @@ class Box(BaseLink):
             self.set_size(d['size'])
 
     def set_size(self, size: List[float]) -> None:
-        msg = 'Box size must be a list of three positive floats'
+        msg = f'Box size {size} must be a list of three positive floats'
         Accessory.assert_valid_triplet(size, msg)
-        assert all([i >= 0.0 for i in size]), msg  # noqa:C419
+        for i in size:
+            if i < 0.0:
+                raise ValueError(msg)
         self.size = size
 
     def get_size(self) -> List[float]:

--- a/clearpath_config/links/types/cylinder.py
+++ b/clearpath_config/links/types/cylinder.py
@@ -74,18 +74,22 @@ class Cylinder(BaseLink):
             self.set_length(d['length'])
 
     def set_radius(self, radius: float) -> None:
-        msg = 'Radius must be a positive float value'
-        assert isinstance(radius, float), msg
-        assert radius >= 0.0, msg
+        msg = f'Radius {radius} must be a positive float value'
+        if not isinstance(radius, float):
+            raise TypeError(msg)
+        if radius < 0.0:
+            raise ValueError(msg)
         self.radius = radius
 
     def get_radius(self) -> float:
         return self.radius
 
     def set_length(self, length: float) -> None:
-        msg = 'Length must be a positive float value'
-        assert isinstance(length, float), msg
-        assert length >= 0.0, msg
+        msg = f'Length {length} must be a positive float value'
+        if not isinstance(length, float):
+            raise TypeError(msg)
+        if length < 0.0:
+            raise ValueError(msg)
         self.length = length
 
     def get_length(self) -> float:

--- a/clearpath_config/links/types/sphere.py
+++ b/clearpath_config/links/types/sphere.py
@@ -67,9 +67,11 @@ class Sphere(BaseLink):
             self.set_radius(d['radius'])
 
     def set_radius(self, radius: float) -> None:
-        msg = 'Radius must be a positive float value'
-        assert isinstance(radius, float), msg
-        assert radius >= 0.0, msg
+        msg = f'Radius {radius} must be a positive float value'
+        if not isinstance(radius, float):
+            raise TypeError(msg)
+        if radius < 0.0:
+            raise ValueError(msg)
         self.radius = radius
 
     def get_radius(self) -> float:

--- a/clearpath_config/manipulators/manipulators.py
+++ b/clearpath_config/manipulators/manipulators.py
@@ -87,7 +87,8 @@ class MoveItConfig(BaseConfig):
 
     @delay.setter
     def delay(self, value: float) -> None:
-        assert value > 0, f'MoveIt delay must be greater than 0. Got {value}'
+        if value <= 0:
+            raise ValueError(f'MoveIt delay must be greater than 0. Got {value}')
         self._delay = value
 
     @property
@@ -96,8 +97,8 @@ class MoveItConfig(BaseConfig):
 
     @ros_parameters.setter
     def ros_parameters(self, value: dict) -> None:
-        assert isinstance(value, dict), (
-            f'MoveIt ROS parameters must be a dictionary. Got {value} instead.')
+        if not isinstance(value, dict):
+            raise TypeError(f'MoveIt ROS parameters must be a dictionary. Got {value} instead.')
         self._ros_parameters = value
 
     def from_dict(self, d: dict) -> None:
@@ -173,9 +174,8 @@ class ManipulatorConfig(BaseConfig):
 
     @moveit.setter
     def moveit(self, value: dict) -> None:
-        assert isinstance(value, dict), (
-            f'MoveIt entry under Manipulators must be of type dict. Got {value}'
-        )
+        if not isinstance(value, dict):
+            raise TypeError(f'MoveIt entry under Manipulators must be of type dict. Got {value}')
         self._moveit = MoveItConfig()
         self._moveit.from_dict(value)
 
@@ -189,8 +189,11 @@ class ManipulatorConfig(BaseConfig):
 
     @arms.setter
     def arms(self, value: List[dict]) -> None:
-        assert isinstance(value, list), 'Manipulators must be of type "dict"'
-        assert all([isinstance(i, dict) for i in value]), 'Manipulators must be of type "dict"'  # noqa:C419, E501
+        if not isinstance(value, list):
+            raise TypeError(f'Manipulators must be of type "dict". Got {value}')
+        for i in value:
+            if not isinstance(i, dict):
+                raise TypeError(f'Manipulators must be of type "dict". Got {i}')
         arms_list = []
         for d in value:
             arm = Arm(d['model'])
@@ -208,10 +211,11 @@ class ManipulatorConfig(BaseConfig):
 
     @lifts.setter
     def lifts(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            "Manipulators must be list of 'dict'")
-        assert all(isinstance(i, dict) for i in value), (
-            "Manipulators must be list of 'dict'")
+        if not isinstance(value, list):
+            raise TypeError(f'Lifts must be list of "dict". Got {value}')
+        for i in value:
+            if not isinstance(i, dict):
+                raise TypeError(f'Lifts must me of type "dict". Got {value}')
         lifts_list = []
         for d in value:
             lift = Lift(d['model'])

--- a/clearpath_config/manipulators/types/arms.py
+++ b/clearpath_config/manipulators/types/arms.py
@@ -324,7 +324,9 @@ class UniversalRobots(BaseArm):
     @ur_type.setter
     def ur_type(self, value: str) -> None:
         if value not in self.UR_TYPES:
-            raise ValueError(f'Universal Robot ur_type must be one of {self.UR_TYPES}, got: "{value}"')
+            raise ValueError(
+                f'Universal Robot ur_type must be one of {self.UR_TYPES}, got: "{value}"'
+            )
 
         self._ur_type = value
 

--- a/clearpath_config/manipulators/types/arms.py
+++ b/clearpath_config/manipulators/types/arms.py
@@ -323,8 +323,8 @@ class UniversalRobots(BaseArm):
 
     @ur_type.setter
     def ur_type(self, value: str) -> None:
-        if value not in self.UR_TYPE:
-            raise ValueError(f'Universal Robot ur_type must be one of {self.UR_TYPES}, got: {value}')
+        if value not in self.UR_TYPES:
+            raise ValueError(f'Universal Robot ur_type must be one of {self.UR_TYPES}, got: "{value}"')
 
         self._ur_type = value
 

--- a/clearpath_config/manipulators/types/arms.py
+++ b/clearpath_config/manipulators/types/arms.py
@@ -323,8 +323,9 @@ class UniversalRobots(BaseArm):
 
     @ur_type.setter
     def ur_type(self, value: str) -> None:
-        assert value in self.UR_TYPES, (
-            f'Universal Robot ur_type must be one of {self.UR_TYPES}, got: {value}')
+        if value not in self.UR_TYPE:
+            raise ValueError(f'Universal Robot ur_type must be one of {self.UR_TYPES}, got: {value}')
+
         self._ur_type = value
 
 
@@ -413,8 +414,8 @@ class Franka(BaseArm):
 
     @arm_id.setter
     def arm_id(self, value: str) -> None:
-        assert value in self.ARM_IDS, (
-            f'Franka arm_id must be one of {self.ARM_IDS}, got: {value}')
+        if value not in self.ARM_IDS:
+            raise ValueError(f'Franka arm_id must be one of {self.ARM_IDS}, got: {value}')
         self._arm_id = value
 
     def set_idx(self, idx: int) -> None:
@@ -440,7 +441,8 @@ class Arm():
 
     @classmethod
     def assert_model(cls, model: str) -> None:
-        assert model in cls.MODEL, f'Arm model "{model}" must be one of "{cls.MODEL.keys()}"'
+        if model not in cls.MODEL:
+            raise ValueError(f'Arm model "{model}" must be one of "{cls.MODEL.keys()}"')
 
     def __new__(cls, model: str) -> BaseArm:
         cls.assert_model(model)

--- a/clearpath_config/manipulators/types/grippers.py
+++ b/clearpath_config/manipulators/types/grippers.py
@@ -161,7 +161,8 @@ class Gripper():
 
     @classmethod
     def assert_model(cls, model: str) -> None:
-        assert model in cls.MODEL, f'Gripper model "{model}" must be one of "{cls.MODEL.keys()}"'
+        if model not in cls.MODEL:
+            raise ValueError(f'Gripper model "{model}" must be one of "{cls.MODEL.keys()}"')
 
     def __new__(cls, arm: BaseManipulator, model: str) -> BaseGripper:
         cls.assert_model(model)

--- a/clearpath_config/manipulators/types/lifts.py
+++ b/clearpath_config/manipulators/types/lifts.py
@@ -118,8 +118,8 @@ class Lift():
 
     @classmethod
     def assert_model(cls, model: str) -> None:
-        assert model in cls.MODEL, (
-            f'Lift model {model} must be one of {cls.MODEL.keys()}')
+        if model not in cls.MODEL:
+            raise ValueError(f'Lift model {model} must be one of {cls.MODEL.keys()}')
 
     def __new__(cls, model: str) -> BaseLift:
         cls.assert_model(model)

--- a/clearpath_config/manipulators/types/manipulator.py
+++ b/clearpath_config/manipulators/types/manipulator.py
@@ -70,7 +70,9 @@ class ManipulatorPose():
         if not isinstance(joints, list):
             raise TypeError(f'Manipulator pose joints must be of type list. Got {joints}')
         if len(joints) != self.joint_count:
-            raise ValueError(f'Manipulator pose joints must of length {self.joint_count}, got {len(joints)}')
+            raise ValueError(
+                f'Manipulator pose joints must of length {self.joint_count}, got {len(joints)}'
+            )
         self._joints = joints
 
     def to_dict(self) -> dict:

--- a/clearpath_config/manipulators/types/manipulator.py
+++ b/clearpath_config/manipulators/types/manipulator.py
@@ -57,8 +57,8 @@ class ManipulatorPose():
 
     @name.setter
     def name(self, name: str) -> None:
-        assert isinstance(name, str), (
-            'Manipulator pose name must be of type str')
+        if not isinstance(name, str):
+            raise TypeError(f'Manipulator pose name must be of type "str". Got {name}')
         self._name = name
 
     @property
@@ -67,10 +67,10 @@ class ManipulatorPose():
 
     @joints.setter
     def joints(self, joints: List) -> None:
-        assert isinstance(joints, list), (
-            'Manipulator pose joints must be of type list')
-        assert len(joints) == self.joint_count, (
-            f'Manipulator pose joints must of length {self.joint_count}, got {len(joints)}')
+        if not isinstance(joints, list):
+            raise TypeError(f'Manipulator pose joints must be of type list. Got {joints}')
+        if len(joints) != self.joint_count:
+            raise ValueError(f'Manipulator pose joints must of length {self.joint_count}, got {len(joints)}')
         self._joints = joints
 
     def to_dict(self) -> dict:
@@ -80,9 +80,12 @@ class ManipulatorPose():
         }
 
     def from_dict(self, d: dict) -> None:
-        assert isinstance(d, dict), ('Poses in list must be of type dict.')
-        assert 'name' in d, ('Pose must have a name entry.')
-        assert 'joints' in d, ('Pose must have a joints entry.')
+        if not isinstance(d, dict):
+            raise TypeError(f'Poses in list must be of type dict. Got {d}')
+        if 'name' not in d:
+            raise ValueError('Pose must have a name entry.')
+        if 'joints' not in d:
+            raise ValueError('Pose must have a joints entry.')
         self.name = d['name']
         self.joints = d['joints']
 
@@ -175,13 +178,13 @@ class BaseManipulator(IndexedAccessory):
 
     @ros_parameters_template.setter
     def ros_parameters_template(self, d: dict) -> None:
-        assert isinstance(d, dict), ('Template must be of type "dict"')
+        if not isinstance(d, dict):
+            raise TypeError(f'Template must be of type "dict". Got {d}')
         # Check that template has all properties
         flat = flatten_dict(d)
-        for _, val in flat.items():
-            assert isinstance(val, property), (
-                'All entries in template must be properties.'
-            )
+        for key, val in flat.items():
+            if not isinstance(val, property):
+                raise TypeError(f'Entry {key} is not a property')
         self._ros_parameters_template = d
 
     @property
@@ -196,7 +199,8 @@ class BaseManipulator(IndexedAccessory):
 
     @ros_parameters.setter
     def ros_parameters(self, d: dict) -> None:
-        assert isinstance(d, dict), ('ROS paramaters must be a dictionary')
+        if not isinstance(d, dict):
+            raise TypeError(f'ROS paramaters must be of type "dict". Got {d}')
         for d_k, d_v in flatten_dict(d).items():
             for key, prop in flatten_dict(self.ros_parameters_template).items():
                 if d_k == key:
@@ -221,7 +225,8 @@ class BaseManipulator(IndexedAccessory):
 
     @poses.setter
     def poses(self, pose_list: List) -> None:
-        assert isinstance(pose_list, list), ('List of poses must be of type list.')
+        if not isinstance(pose_list, list):
+            raise TypeError(f'List of poses must be of type list. Got {pose_list}')
         poses_ = []
         for pose in pose_list:
             manipulator_pose = ManipulatorPose(self.JOINT_COUNT)

--- a/clearpath_config/mounts/mounts.py
+++ b/clearpath_config/mounts/mounts.py
@@ -53,7 +53,8 @@ class Mount():
     }
 
     def __new__(cls, model: str) -> BaseMount:
-        assert model in Mount.MODEL, f'Model "{model}" must be one of "{Mount.MODEL.keys()}"'
+        if model not in Mount.MODEL:
+            raise ValueError(f'Model "{model}" must be one of "{Mount.MODEL.keys()}"')
         return Mount.MODEL[model]()
 
 
@@ -139,10 +140,11 @@ class MountsConfig(BaseConfig):
 
     @bracket.setter
     def bracket(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            'Mounts must be list of type "dict"')
-        assert all([isinstance(i, dict) for i in value]), (  # noqa:C419
-            'Mounts must be list of type "dict"')
+        if not isinstance(value, list):
+            raise TypeError(f'Brackets must be list of type "dict". Got {value}')
+        for i in value:
+            if not isinstance(i, dict):
+                raise TypeError(f'Bracket {i} must be of type "dict"')
         mounts = MountListConfig()
         mount_list = []
         for d in value:
@@ -162,10 +164,11 @@ class MountsConfig(BaseConfig):
 
     @riser.setter
     def riser(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            'Mounts must be list of "dict"')
-        assert all([isinstance(i, dict) for i in value]), (  # noqa:C419
-            'Mounts must be list of "dict"')
+        if not isinstance(value, list):
+            raise TypeError(f'Risers must be list of "dict". Got {value}')
+        for i in value:
+            if not isinstance(i, dict):
+                raise TypeError(f'Riser {i} must be of type "dict".')
         mounts = MountListConfig()
         mount_list = []
         for d in value:
@@ -185,10 +188,11 @@ class MountsConfig(BaseConfig):
 
     @fath_pivot.setter
     def fath_pivot(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            'Mounts must be list of "dict"')
-        assert all([isinstance(i, dict) for i in value]), (  # noqa:C419
-            'Mounts must be list of "dict"')
+        if not isinstance(value, list):
+            raise TypeError(f'Fath pivot mounts must be list of "dict". Got {value}')
+        for i in value:
+            if not isinstance(i, dict):
+                raise TypeError(f'Fath pivot mount {i} must be of type "dict"')
         mounts = MountListConfig()
         mount_list = []
         for d in value:
@@ -208,10 +212,11 @@ class MountsConfig(BaseConfig):
 
     @sick_stand.setter
     def sick_stand(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            'Mounts must be list of "dict"')
-        assert all([isinstance(i, dict) for i in value]), (  # noqa:C419
-            'Mounts must be list of "dict"')
+        if not isinstance(value, list):
+            raise TypeError(f'Sick stands must be list of "dict". Got {value}')
+        for i in value:
+            if not isinstance(i, dict):
+                raise TypeError('Sick stand {i} must be of type "dict"')
         mounts = MountListConfig()
         mount_list = []
         for d in value:
@@ -231,10 +236,11 @@ class MountsConfig(BaseConfig):
 
     @post.setter
     def post(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            'Mounts must be list of "dict"')
-        assert all([isinstance(i, dict) for i in value]), (  # noqa:C419
-            'Mounts must be list of "dict"')
+        if not isinstance(value, list):
+            raise TypeError(f'Posts must be list of "dict". Got {value}')
+        for i in value:
+            if not isinstance(i, dict):
+                raise TypeError(f'Post {i} must be of type "dict"')
         mounts = MountListConfig()
         mount_list = []
         for d in value:
@@ -254,10 +260,11 @@ class MountsConfig(BaseConfig):
 
     @disk.setter
     def disk(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            'Mounts must be list of "dict"')
-        assert all([isinstance(i, dict) for i in value]), (  # noqa:C419
-            'Mounts must be list of "dict"')
+        if not isinstance(value, list):
+            raise TypeError(f'Disks must be list of "dict". Got {value}')
+        for i in value:
+            if not isinstance(i, dict):
+                raise TypeError(f'Disk {i} must be of type "dict"')
         mounts = MountListConfig()
         mount_list = []
         for d in value:

--- a/clearpath_config/mounts/types/fath_pivot.py
+++ b/clearpath_config/mounts/types/fath_pivot.py
@@ -67,5 +67,6 @@ class FathPivot(BaseMount):
         return self.angle
 
     def set_angle(self, angle: float) -> None:
-        assert -pi < angle <= pi, f'Angle "{angle}" must be in radian and  between -pi and pi'
+        if angle <= -pi or angle > pi:
+            raise ValueError(f'Angle {angle} must be in radians between -pi and +pi')
         self.angle = angle

--- a/clearpath_config/mounts/types/flir_ptu.py
+++ b/clearpath_config/mounts/types/flir_ptu.py
@@ -47,6 +47,9 @@ class FlirPTU(BaseMount):
     # TCP (uses ip_addr and tcp_port)
     CONNECTION_TYPES = [TTY, TCP]
 
+    MIN_PORT = 1024
+    MAX_PORT = 65535
+
     def __init__(
         self,
         parent: str = Accessory.PARENT,
@@ -90,7 +93,12 @@ class FlirPTU(BaseMount):
         return self.tcp_port
 
     def set_tcp_port(self, tcp_port: int) -> None:
-        assert 1024 < tcp_port < 65536, f'TCP port "{tcp_port}" must be in range 1024 to 65536'
+        if not isinstance(tcp_port, int):
+            raise TypeError(f'TCP port {tcp_port} must be of type "int"')
+        if tcp_port < self.MIN_PORT or tcp_port > self.MAX_PORT:
+            raise ValueError(
+                f'TCP port {tcp_port} must be in range {self.MIN_PORT} to {self.MAX_PORT}'
+            )
         self.tcp_port = tcp_port
 
     def get_ip(self) -> str:
@@ -103,7 +111,10 @@ class FlirPTU(BaseMount):
         return self.connection_type
 
     def set_connection_type(self, connection_type: str) -> None:
-        assert connection_type in self.CONNECTION_TYPES, f'Connection type "{connection_type}" must be one of "{self.CONNECTION_TYPES}"'  # noqa:E501
+        if connection_type not in self.CONNECTION_TYPES:
+            raise ValueError(
+                f'Connection type "{connection_type}" must be one of "{self.CONNECTION_TYPES}"'
+            )
         self.connection_type = connection_type
 
     def get_limits_enabled(self) -> bool:

--- a/clearpath_config/mounts/types/pacs.py
+++ b/clearpath_config/mounts/types/pacs.py
@@ -83,34 +83,38 @@ class PACS:
             return self.rows
 
         def set_rows(self, rows: int) -> None:
-            assert isinstance(rows, int), (
-                'Riser rows must be an integer.'
-            )
-            assert 0 < rows <= PACS.MAX_ROWS, f'Riser rows must be between 0 and {PACS.MAX_ROWS}'
+            if not isinstance(rows, int):
+                raise TypeError(f'Riser rows {rows} must be of type "int"')
+            if rows <= 0 or rows > PACS.MAX_ROWS:
+                raise ValueError(f'Riser rows {rows} must be between 0 and {PACS.MAX_ROWS}')
             self.rows = rows
 
         def get_columns(self) -> int:
             return self.columns
 
         def set_columns(self, columns: int):
-            assert isinstance(columns, int), (
-                'Riser columns must be an integer.'
-            )
-            assert 0 < columns <= PACS.MAX_COLUMNS, f'Riser rows must be between 0 and {PACS.MAX_COLUMNS}'  # noqa:E501
+            if not isinstance(columns, int):
+                raise TypeError(f'Riser columns {columns} must be of type "int"')
+            if columns <= 0 or columns > PACS.MAX_COLUMNS:
+                raise ValueError(
+                    f'Riser columns {columns} must be between 0 and {PACS.MAX_COLUMNS}'
+                )
             self.columns = columns
 
         def get_height(self) -> float:
             return self.height
 
         def set_height(self, height: float) -> None:
-            assert height >= 0, 'Height must be at least 0'
+            if height < 0:
+                raise ValueError(f'Height {height} must be at least 0.0')
             self.height = height
 
         def get_thickness(self) -> None:
             return self.thickness
 
         def set_thickness(self, thickness: float) -> None:
-            assert thickness > 0, 'Thickness must be greater than 0'
+            if thickness <= 0:
+                raise ValueError(f'Thickness {thickness} must be greater than 0.0')
             self.thickness = thickness
 
     class Bracket(BaseMount):
@@ -154,5 +158,8 @@ class PACS:
             return self.model
 
         def set_model(self, model: str) -> None:
-            assert model in self.MODELS, f'Unexpected Bracket model "{model}". It must be one of "{self.MODELS}"'  # noqa:E501
+            if model not in self.MODELS:
+                raise ValueError(
+                    f'Unexpected Bracket model "{model}". It must be one of "{self.MODELS}"'
+                )
             self.model = model

--- a/clearpath_config/mounts/types/post.py
+++ b/clearpath_config/mounts/types/post.py
@@ -77,7 +77,8 @@ class Post(BaseMount):
         return self.model
 
     def set_model(self, model: str) -> None:
-        assert model in self.MODELS, f'Unexpected Post model "{model}". It must be one of "{self.MODELS}"'  # noqa:E501
+        if model not in self.MODELS:
+            raise ValueError(f'Unexpected Post model "{model}". It must be one of "{self.MODELS}"')
         self.model = model
 
     @property
@@ -86,8 +87,8 @@ class Post(BaseMount):
 
     @height.setter
     def height(self, height: float) -> None:
-        assert height > 0, (
-            'Height must be positive "float"')
+        if height <= 0.0:
+            raise ValueError(f'Height {height} must be greater than 0.0')
         self._height = height
 
     @property
@@ -96,6 +97,6 @@ class Post(BaseMount):
 
     @spacing.setter
     def spacing(self, spacing: float) -> None:
-        assert spacing > 0, (
-            'Spacing must be positive "float"')
+        if spacing <= 0.0:
+            raise ValueError(f'Spacing {spacing} must be greater than 0.0')
         self._spacing = spacing

--- a/clearpath_config/mounts/types/sick.py
+++ b/clearpath_config/mounts/types/sick.py
@@ -63,5 +63,8 @@ class SICKStand(BaseMount):
         return self.model
 
     def set_model(self, model: str) -> None:
-        assert model in self.MODELS, f'Unexpected SICK stand model "{model}".  It must be one of "{self.MODELS}"'  # noqa:E501
+        if model not in self.MODELS:
+            raise ValueError(
+                f'Unexpected SICK stand model "{model}".  It must be one of "{self.MODELS}"'
+            )
         self.model = model

--- a/clearpath_config/platform/attachments/mux.py
+++ b/clearpath_config/platform/attachments/mux.py
@@ -56,7 +56,8 @@ class AttachmentsConfigMux:
 
     def __new__(cls, platform: str, attachments: dict = None) -> AttachmentsConfig:
         # Check Platform is Supported
-        assert platform in cls.PLATFORM, f'Platform "{platform}" must be one of "{cls.PLATFORM.keys()}"'  # noqa:E501
+        if platform not in cls.PLATFORM:
+            raise ValueError(f'Platform "{platform}" must be one of "{cls.PLATFORM.keys()}"')
         if not attachments:
             return cls.PLATFORM[platform]
         # Pre-Process Entries
@@ -71,9 +72,11 @@ class AttachmentsConfigMux:
     @staticmethod
     def preprocess(platform: str, attachments: dict):
         for i, a in enumerate(attachments):
-            assert 'name' in a, 'An attachment is missing "name"'
-            assert 'type' in a, 'An attachment is missing "type"'
+            if 'name' not in a:
+                raise ValueError(f'Attachment {a} is missing parameter "name"')
+            if 'type' not in a:
+                raise ValueError(f'Attachment {a} is missing parameter "type"')
             if '.' not in a['type']:
-                a['type'] = '%s.%s' % (platform, a['type'])
+                a['type'] = f'{platform}.{a["type"]}'
             attachments[i] = a
         return attachments

--- a/clearpath_config/platform/battery.py
+++ b/clearpath_config/platform/battery.py
@@ -187,8 +187,14 @@ class BatteryConfig(BaseConfig):
     @model.setter
     def model(self, value: str) -> None:
         platform = BaseConfig.get_platform_model()
-        assert platform in self.VALID, f'Platform "{platform}" is invalid. Must be one of "{list(self.VALID)}"'  # noqa:E501
-        assert value in self.VALID[platform], f'Battery model "{value}" is invalid. Battery model for platform "{platform}" must be one of "{list(self.VALID[platform])}"'  # noqa:E501
+        if platform not in self.VALID:
+            raise ValueError(
+                f'Platform "{platform}" is invalid. Must be one of "{list(self.VALID)}"'
+            )
+        if value not in self.VALID[platform]:
+            raise ValueError(
+                f'Battery model "{value}" is invalid. Battery model for platform "{platform}" must be one of "{list(self.VALID[platform])}"'  # noqa:E501
+            )
         self._model = value
 
     @property
@@ -202,12 +208,18 @@ class BatteryConfig(BaseConfig):
     @configuration.setter
     def configuration(self, value: str) -> None:
         platform = BaseConfig.get_platform_model()
-        assert platform in self.VALID, ((
-            'Platform %s is invalid. ' % platform +
-            'Platform must be one of: %s' % list(self.VALID)
-        ))
-        assert self.model in self.VALID[platform], f'Battery model "{self.model}" is invalid. Battery model for platform "{platform}" it must be one of "{list(self.VALID[platform])}"'  # noqa:E501
-        assert value in self.VALID[platform][self.model], f'Battery configuration "{value}" is invalid. For platform "{platform}" and battery model "{self.model}" it must be one of "{list(self.VALID[platform][self.model])}"'  # noqa:E501
+        if platform not in self.VALID:
+            raise ValueError(
+                f'Platform {platform} is invalid. Must be one of: {list(self.VALID)}'
+            )
+        if self.model not in self.VALID[platform]:
+            raise ValueError(
+                f'Battery model "{self.model}" is invalid. Battery model for platform "{platform}" it must be one of "{list(self.VALID[platform])}"'  # noqa:E501
+            )
+        if value not in self.VALID[platform][self.model]:
+            raise ValueError(
+                f'Battery configuration "{value}" is invalid. For platform "{platform}" and battery model "{self.model}" it must be one of "{list(self.VALID[platform][self.model])}"'  # noqa:E501
+            )
         self._configuration = value
 
     @property
@@ -220,8 +232,6 @@ class BatteryConfig(BaseConfig):
 
     @launch_args.setter
     def launch_args(self, value: dict) -> None:
-        assert isinstance(value, dict), ((
-            'Battery Launch args %s are invalid. ' % value +
-            'They must be in the format of a dictionary.'
-        ))
+        if not isinstance(value, dict):
+            raise TypeError(f'Battery Launch args {value} must be of type "dict"')
         self._launch_args = value

--- a/clearpath_config/platform/can.py
+++ b/clearpath_config/platform/can.py
@@ -163,7 +163,8 @@ class CANAdapter:
     }
 
     def __new__(cls, type_: str) -> PhysicalCANAdapter:
-        assert type_ in cls.TYPES, f'CANAdapter model, {type_}, not one of {cls.TYPES}'
+        if type_ not in cls.TYPES:
+            raise ValueError(f'CANAdapter model, {type_}, not one of {cls.TYPES}')
         return cls.TYPES[type_]()
 
 
@@ -227,7 +228,8 @@ class CANAdapterConfig:
     @config.setter
     def config(self, can_adapters: list):
         for d in can_adapters:
-            assert 'type' in d,  'CAN adapter must have "type" parameter defined'
+            if 'type' not in d:
+                raise ValueError(f'CAN adapter {d} must have "type" parameter defined')
             adapter = CANAdapter(d['type'])
             adapter.from_dict(d)
             self._can_adapters.set(adapter)

--- a/clearpath_config/platform/drivetrain.py
+++ b/clearpath_config/platform/drivetrain.py
@@ -226,14 +226,14 @@ class DrivetrainConfig(BaseConfig):
     @control.setter
     def control(self, value: str) -> None:
         platform = BaseConfig.get_platform_model()
-        assert platform in self.VALID, (
-            f'Platform "{platform}" is invalid. Must be one of "{list(self.VALID)}"'
-        )  # noqa:E501
-        assert value in self.VALID[platform][self.CONTROL], (
-            f'Drivetrain control "{value}" is invalid. '
-            f'Drivetrain control for platform "{platform}" must be '
-            f'one of "{list(self.VALID[platform][self.CONTROL])}"'
-        )  # noqa:E501
+        if platform not in self.VALID:
+            raise ValueError(
+                f'Platform "{platform}" is invalid. Must be one of "{list(self.VALID)}"'
+            )
+        if value not in self.VALID[platform][self.CONTROL]:
+            raise ValueError(
+                f'Drivetrain control "{value}" is invalid. Drivetrain control for platform "{platform}" must be one of "{list(self.VALID[platform][self.CONTROL])}"'  # noqa:E501
+            )
         self._control = value
         # Check that front wheels are valid with updated control
         if self.front_wheels not in list(
@@ -260,21 +260,21 @@ class DrivetrainConfig(BaseConfig):
     @front_wheels.setter
     def front_wheels(self, value: str) -> None:
         platform = BaseConfig.get_platform_model()
-        assert platform in self.VALID, (
-            f'Platform "{platform}" is invalid. Must be one of "{list(self.VALID[self.WHEELS])}"'
-        )  # noqa:E501
-        assert self.control in self.VALID[platform][self.CONTROL], (
-            f'Drivetrain control "{self.control}" is invalid. '
-            f'Drivetrain control for platform "{platform}" must be '
-            f'one of "{list(self.VALID[self.CONTROL][platform])}"'
-        )  # noqa:E501
-        assert value in self.VALID[platform][self.WHEELS][self.FRONT] and \
-               value in self.VALID_WHEELS[self.control][self.FRONT], (
-            f'Front wheel type "{value}" is invalid. '
-            f'For platform "{platform}" and drivetrain "{self.control}" it must be '
-            f'one of "{list(set(self.VALID[platform][self.WHEELS][self.FRONT]).intersection(
-                 self.VALID_WHEELS[self.control][self.FRONT]))}"'
-        )  # noqa:E501
+        if platform not in self.VALID:
+            raise ValueError(
+                f'Platform "{platform}" is invalid. Must be one of "{list(self.VALID[self.WHEELS])}"'  # noqa:E501
+            )
+        if self.config not in self.VALID[platform][self.CONTROL]:
+            raise ValueError(
+                f'Drivetrain control "{self.control}" is invalid. Drivetrain control for platform "{platform}" must be one of "{list(self.VALID[self.CONTROL][platform])}"'  # noqa: E501
+            )
+        if (
+            value not in self.VALID[platform][self.WHEELS][self.FRONT]
+            or value not in self.VALID_WHEELS[self.control][self.FRONT]
+        ):
+            raise ValueError(
+                f'Front wheel type "{value}" is invalid. For platform "{platform}" and drivetrain "{self.control}" it must be one of "{list(set(self.VALID[platform][self.WHEELS][self.FRONT]).intersection(self.VALID_WHEELS[self.control][self.FRONT]))}"'  # noqa:E501
+            )
         self._front_wheels = value
 
     @property
@@ -287,19 +287,19 @@ class DrivetrainConfig(BaseConfig):
     @rear_wheels.setter
     def rear_wheels(self, value: str) -> None:
         platform = BaseConfig.get_platform_model()
-        assert platform in self.VALID, (
-            f'Platform "{platform}" is invalid. Must be one of "{list(self.VALID[self.WHEELS])}"'
-        )  # noqa:E501
-        assert self.control in self.VALID[platform][self.CONTROL], (
-            f'Drivetrain control "{self.control}" is invalid. '
-            f'Drivetrain control for platform "{platform}" must be '
-            f'one of "{list(self.VALID[self.CONTROL][platform])}"'
-        )  # noqa:E501
-        assert value in self.VALID[platform][self.WHEELS][self.REAR] and \
-               value in self.VALID_WHEELS[self.control][self.REAR], (
-            f'Rear wheel type "{value}" is invalid. '
-            f'For platform "{platform}" and drivetrain "{self.control}" it must be '
-            f'one of "{list(set(self.VALID[platform][self.WHEELS][self.REAR]).intersection(
-                 self.VALID_WHEELS[self.control][self.REAR]))}"'
-        )  # noqa:E501
+        if platform not in self.VALID:
+            raise ValueError(
+                f'Platform "{platform}" is invalid. Must be one of "{list(self.VALID[self.WHEELS])}"'  # noqa: E501
+            )
+        if self.control not in self.VALID[platform][self.CONTROL]:
+            raise ValueError(
+                f'Drivetrain control "{self.control}" is invalid. Drivetrain control for platform "{platform}" must be one of "{list(self.VALID[self.CONTROL][platform])}"'  # noqa: E501
+            )
+        if (
+            value not in self.VALID[platform][self.WHEELS][self.REAR]
+            or value not in self.VALID_WHEELS[self.control][self.REAR]
+        ):
+            raise ValueError(
+                f'Rear wheel type "{value}" is invalid. For platform "{platform}" and drivetrain "{self.control}" it must be one of "{list(set(self.VALID[platform][self.WHEELS][self.REAR]).intersection(self.VALID_WHEELS[self.control][self.REAR]))}"'  # noqa:E501
+            )
         self._rear_wheels = value

--- a/clearpath_config/platform/drivetrain.py
+++ b/clearpath_config/platform/drivetrain.py
@@ -264,7 +264,7 @@ class DrivetrainConfig(BaseConfig):
             raise ValueError(
                 f'Platform "{platform}" is invalid. Must be one of "{list(self.VALID[self.WHEELS])}"'  # noqa:E501
             )
-        if self.config not in self.VALID[platform][self.CONTROL]:
+        if self.control not in self.VALID[platform][self.CONTROL]:
             raise ValueError(
                 f'Drivetrain control "{self.control}" is invalid. Drivetrain control for platform "{platform}" must be one of "{list(self.VALID[self.CONTROL][platform])}"'  # noqa: E501
             )

--- a/clearpath_config/platform/extras.py
+++ b/clearpath_config/platform/extras.py
@@ -281,6 +281,9 @@ class ExtrasConfig(BaseConfig):
 
     @launch.setter
     def launch(self, value: List[LaunchConfig] | List[dict] | LaunchConfig | dict) -> None:
+        if value is None:
+            value = []
+
         # Previously only a single launch file was supported
         # For compatibility, transform the old format to the new one, but print a deprecation
         # notice, as this translation layer may be removed in the future

--- a/clearpath_config/platform/extras.py
+++ b/clearpath_config/platform/extras.py
@@ -162,7 +162,8 @@ class ROSParameterDefaults:
     }
 
     def __new__(cls, platform: str) -> dict:
-        assert platform in Platform.ALL
+        if platform not in Platform.ALL:
+            raise ValueError(f'Platform {platform} must be one of {Platform.ALL}')
         return cls.DEFAULTS[platform]
 
 
@@ -271,9 +272,14 @@ class ExtrasConfig(BaseConfig):
             self._urdf = value
         else:
             self._urdf = self.DEFAULTS[self.URDF]
-            assert not value or isinstance(value, dict) or (isinstance(value, PackagePath)), (
-                'Extras URDF must be null or of type `dict` or `PackagePath`'
-            )
+            if (
+                value
+                and not isinstance(value, dict)
+                and not isinstance(value, PackagePath)
+            ):
+                raise TypeError(
+                    f'Extras URDF {value} must be null, or of type "dict" or "PackagePath'
+                )
 
     @property
     def launch(self) -> List[LaunchConfig]:
@@ -300,9 +306,13 @@ class ExtrasConfig(BaseConfig):
             elif isinstance(path, LaunchConfig) and path.path:
                 self._launch.append(path)
             else:
-                assert not path or isinstance(path, dict) or isinstance(path, LaunchConfig), (
-                    'Extras LAUNCH must be list of type "dict" or "LaunchConfig"'
-                )
+                if (
+                    not isinstance(path, dict)
+                    and not isinstance(path, LaunchConfig)
+                ):
+                    raise TypeError(
+                        f'Extras Launch {path} must be list of type "dict" or "LaunchConfig"'
+                    )
 
     def _is_ros_parameter(self, key) -> bool:
         return any([key in i for i in self._ros_parameters_setters])  # noqa:C419

--- a/clearpath_config/platform/launch.py
+++ b/clearpath_config/platform/launch.py
@@ -93,7 +93,8 @@ class LaunchConfig(BaseConfig):
 
     @path.setter
     def path(self, path: str) -> None:
-        assert isinstance(path, str), f'Path {path} must be a string'
+        if not isinstance(path, str):
+            raise TypeError(f'Path {path} must be a string')
         self._path = path
 
     @property
@@ -102,7 +103,11 @@ class LaunchConfig(BaseConfig):
 
     @package.setter
     def package(self, package: str) -> None:
-        assert package is None or isinstance(package, str), f'Package {package} must be a string'
+        if (
+            package is not None
+            and not isinstance(package, str)
+        ):
+            raise TypeError(f'Package {package} must be null or a string')
         self._package = package
 
     @property
@@ -114,8 +119,10 @@ class LaunchConfig(BaseConfig):
         if args is None:
             args = {}
 
-        assert isinstance(args, dict), 'Arguments must be of type "dict"'
+        if not isinstance(args, dict):
+            raise TypeError(f'Arguments {args} must be of type "dict"')
         self._args = {}
         for arg in args:
-            assert isinstance(arg, str), f'Argument key {arg} must be of type "str"'
+            if not isinstance(arg, str):
+                raise TypeError(f'Argument key {arg} must be of type "str"')
             self._args[arg] = args[arg]

--- a/clearpath_config/platform/platform.py
+++ b/clearpath_config/platform/platform.py
@@ -249,7 +249,8 @@ class PlatformConfig(BaseConfig):
 
     @controller.setter
     def controller(self, value: str) -> None:
-        assert value.lower() in self.CONTROLLERS, f'"{value.lower()}" controller is invalid. Must be one of "{self.CONTROLLERS}"'  # noqa:501
+        if value.lower() not in self.CONTROLLERS:
+            raise ValueError(f'"{value.lower()}" controller is invalid. Must be one of "{self.CONTROLLERS}"')  # noqa:501
         self._controller = value.lower()
 
     @property
@@ -308,10 +309,8 @@ class PlatformConfig(BaseConfig):
         elif isinstance(value, ExtrasConfig):
             self._extras = value
         else:
-            assert isinstance(value, dict) or (
-                    isinstance(value, ExtrasConfig)), (
-                'Extras must be of type "dict" or "ExtrasConfig"'
-            )
+            if not (isinstance(value, dict) or isinstance(value, ExtrasConfig)):
+                raise TypeError(f'Extras {value} must be of type "dict" or "ExtrasConfig"')
 
     def get_controller(self) -> str:
         return self.controller
@@ -376,8 +375,8 @@ class PlatformConfig(BaseConfig):
         elif isinstance(value, BatteryConfig):
             self._battery = value
         else:
-            assert isinstance(value, dict) or (
-                isinstance(value, BatteryConfig)), 'Battery configuration must be of type "dict" or "BatteryConfig"'  # noqa:E501
+            if not (isinstance(value, dict) or isinstance(value, BatteryConfig)):
+                raise TypeError(f'Battery configuration {value} must be of type "dict" or "BatteryConfig"')  # noqa:E501
 
     @property
     def drivetrain(self) -> DrivetrainConfig:
@@ -394,8 +393,8 @@ class PlatformConfig(BaseConfig):
         elif isinstance(value, DrivetrainConfig):
             self._drivetrain = value
         else:
-            assert isinstance(value, dict) or (
-                isinstance(value, DrivetrainConfig)), 'Drivetrain configuration must be of type "dict" or "DrivetrainConfig"'  # noqa:E501
+            if not (isinstance(value, dict) or isinstance(value, DrivetrainConfig)):
+                raise TypeError(f'Drivetrain configuration {value} must be of type "dict" or "DrivetrainConfig"')  # noqa:E501
 
     @property
     def enable_ekf(self) -> bool:

--- a/clearpath_config/platform/types/attachment.py
+++ b/clearpath_config/platform/types/attachment.py
@@ -80,7 +80,8 @@ class BaseAttachment(Accessory):
         return self.model
 
     def set_model(self, model: str) -> None:
-        assert model in self.MODELS, f'{self.ATTACHMENT_MODEL.title()} model "{model}" is not not of "{self.MODELS}"'  # noqa:E501
+        if model not in self.MODELS:
+            raise ValueError(f'{self.ATTACHMENT_MODEL.title()} model "{model}" is not not of "{self.MODELS}"')  # noqa:E501
         self.model = model
 
 
@@ -93,5 +94,6 @@ class PlatformAttachment(BaseAttachment):
         return _type in cls.TYPES
 
     def __new__(cls, _type: str) -> BaseAttachment:
-        assert cls.is_valid(_type), f'{cls.PLATFORM} does not have attachment "{_type}". Must be one of "{cls.TYPES}"'  # noqa:E501
+        if not cls.is_valid(_type):
+            raise ValueError(f'{cls.PLATFORM} does not have attachment "{_type}". Must be one of "{cls.TYPES}"')  # noqa:E501
         return cls.TYPES[_type]

--- a/clearpath_config/platform/types/bumper.py
+++ b/clearpath_config/platform/types/bumper.py
@@ -74,10 +74,8 @@ class Bumper(BaseAttachment):
     def set_extension(self, extension: float) -> None:
         try:
             extension = float(extension)
-        except ValueError as e:
-            raise AssertionError(e.args[0])
-        assert isinstance(
-            extension, float
-        ), f'Bumper extension must be of type float, unexpected type {type(extension)}'
-        assert extension >= 0, 'Bumper extension must be a positive value'
+        except ValueError:
+            raise TypeError(f'Bumper extension {extension} must be of type "float"')
+        if extension < 0:
+            raise ValueError(f'Bumper extension {extension} must be a positive value')
         self.extension = extension

--- a/clearpath_config/sensors/sensors.py
+++ b/clearpath_config/sensors/sensors.py
@@ -91,7 +91,8 @@ class InertialMeasurementUnit():
 
     @classmethod
     def assert_model(cls, model: str) -> None:
-        assert model in cls.MODEL, f'Model "{model}" must be one of "{cls.MODEL.keys()}"'
+        if model not in cls.MODEL:
+            raise ValueError(f'Model "{model}" must be one of "{cls.MODEL.keys()}"')
 
     def __new__(cls, model: str) -> BaseIMU:
         cls.assert_model(model)
@@ -115,7 +116,8 @@ class Camera():
 
     @classmethod
     def assert_model(cls, model: str) -> None:
-        assert model in cls.MODEL, f'Model "{model}" must be one of "{cls.MODEL.keys()}"'
+        if model not in cls.MODEL:
+            raise ValueError(f'Model "{model}" must be one of "{cls.MODEL.keys()}"')
 
     def __new__(cls, model: str) -> BaseCamera:
         cls.assert_model(model)
@@ -131,7 +133,8 @@ class Charger():
 
     @classmethod
     def assert_model(cls, model: str) -> None:
-        assert model in cls.MODEL, f'Charger model "{model}" must be one of "{cls.MODEL.keys()}"'
+        if model not in cls.MODEL:
+            raise ValueError(f'Charger model "{model}" must be one of "{cls.MODEL.keys()}"')
 
     def __new__(cls, model: str) -> BaseCamera:
         cls.assert_model(model)
@@ -155,7 +158,8 @@ class GlobalPositioningSystem():
 
     @classmethod
     def assert_model(cls, model: str) -> None:
-        assert model in cls.MODEL, f'Model "{model}" must be one of "{cls.MODEL.keys()}"'
+        if model not in cls.MODEL:
+            raise ValueError(f'Model "{model}" must be one of "{cls.MODEL.keys()}"')
 
     def __new__(cls, model: str) -> BaseGPS:
         cls.assert_model(model)
@@ -173,7 +177,8 @@ class Lidar2D():
 
     @classmethod
     def assert_model(cls, model: str) -> None:
-        assert model in cls.MODEL, f'Model "{model}" must be one of "{cls.MODEL.keys()}"'
+        if model not in cls.MODEL:
+            raise ValueError(f'Model "{model}" must be one of "{cls.MODEL.keys()}"')
 
     def __new__(cls, model: str) -> BaseLidar2D:
         cls.assert_model(model)
@@ -193,7 +198,8 @@ class Lidar3D():
 
     @classmethod
     def assert_model(cls, model: str) -> None:
-        assert model in cls.MODEL, f'Model "{model}" must be one of "{cls.MODEL.keys()}"'
+        if model not in cls.MODEL:
+            raise ValueError(f'Model "{model}" must be one of "{cls.MODEL.keys()}"')
 
     def __new__(cls, model: str) -> BaseLidar3D:
         cls.assert_model(model)
@@ -209,7 +215,8 @@ class INS():
 
     @classmethod
     def assert_model(cls, model: str) -> None:
-        assert model in cls.MODEL, f'Model "{model}" must be one of "{cls.MODEL.keys()}"'
+        if model not in cls.MODEL:
+            raise ValueError(f'Model "{model}" must be one of "{cls.MODEL.keys()}"')
 
     def __new__(cls, model: str) -> BaseINS:
         cls.assert_model(model)
@@ -233,7 +240,8 @@ class Sensor():
 
     @classmethod
     def assert_type(cls, _type: str) -> None:
-        assert _type in cls.TYPE, f'Sensor type "{_type}" must be one of "{cls.TYPE.keys()}"'
+        if _type not in cls.TYPE:
+            raise ValueError(f'Sensor type "{_type}" must be one of "{cls.TYPE.keys()}"')
 
     def __new__(cls, _type: str, _model: str) -> BaseSensor:
         cls.assert_type(_type)
@@ -354,12 +362,13 @@ class SensorConfig(BaseConfig):
 
     @camera.setter
     def camera(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            'Sensors must be list of "dict"')
-        assert all([isinstance(d, dict) for d in value]), (  # noqa: C419
-            'Sensors must be list of "dict"')
-        assert all(['model' in d for d in value]), (  # noqa: C419
-            'Sensor "dict" must have "model" key')
+        if not isinstance(value, list):
+            raise TypeError(f'Camera must be list of "dict". Got {value}')
+        for d in value:
+            if not isinstance(d, dict):
+                raise TypeError(f'Camera {d} must be of type "dict"')
+            if 'model' not in d:
+                raise ValueError(f'Camera {d} does not have a "model" parameter')
         sensor_list = []
         for d in value:
             sensor = Camera(d['model'])
@@ -377,12 +386,13 @@ class SensorConfig(BaseConfig):
 
     @charger.setter
     def charger(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            'Sensors must be list of "dict"')
-        assert all([isinstance(d, dict) for d in value]), (  # noqa: C419
-            'Sensors must be list of "dict"')
-        assert all(['model' in d for d in value]), (  # noqa: C419
-            'Sensor "dict" must have "model" key')
+        if not isinstance(value, list):
+            raise TypeError(f'Chargers must be list of "dict". Got {value}')
+        for d in value:
+            if not isinstance(d, dict):
+                raise TypeError(f'Charger {d} must be of type "dict"')
+            if 'model' not in d:
+                raise ValueError(f'Charger {d} does not have a "model" parameter')
         sensor_list = []
         for d in value:
             sensor = Charger(d['model'])
@@ -400,12 +410,13 @@ class SensorConfig(BaseConfig):
 
     @gps.setter
     def gps(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            'Sensors must be list of "dict"')
-        assert all([isinstance(d, dict) for d in value]), (  # noqa: C419
-            'Sensors must be list of "dict"')
-        assert all(['model' in d for d in value]), (  # noqa: C419
-            'Sensor "dict" must have "model" key')
+        if not isinstance(value, list):
+            raise TypeError(f'GPS must be list of "dict". Got {value}')
+        for d in value:
+            if not isinstance(d, dict):
+                raise TypeError(f'GPS {d} must be of type "dict"')
+            if 'model' not in d:
+                raise ValueError(f'GPS {d} does not have a "model" parameter')
         sensor_list = []
         for d in value:
             sensor = GlobalPositioningSystem(d['model'])
@@ -423,12 +434,13 @@ class SensorConfig(BaseConfig):
 
     @imu.setter
     def imu(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            'Sensors must be list of "dict"')
-        assert all([isinstance(d, dict) for d in value]), (  # noqa: C419
-            'Sensors must be list of "dict"')
-        assert all(['model' in d for d in value]), (  # noqa: C419
-            'Sensor "dict" must have "model" key')
+        if not isinstance(value, list):
+            raise TypeError(f'IMUs must be list of "dict". Got {value}')
+        for d in value:
+            if not isinstance(d, dict):
+                raise TypeError(f'IMU {d} must be of type "dict"')
+            if 'model' not in d:
+                raise ValueError(f'IMU {d} does not have a "model" parameter')
         sensor_list = []
         for d in value:
             sensor = InertialMeasurementUnit(d['model'])
@@ -446,12 +458,13 @@ class SensorConfig(BaseConfig):
 
     @lidar2d.setter
     def lidar2d(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            'Sensors must be list of "dict"')
-        assert all([isinstance(d, dict) for d in value]), (  # noqa: C419
-            'Sensors must be list of "dict"')
-        assert all(['model' in d for d in value]), (  # noqa: C419
-            'Sensor "dict" must have "model" key')
+        if not isinstance(value, list):
+            raise TypeError(f'2D Lidars must be list of "dict". Got {value}')
+        for d in value:
+            if not isinstance(d, dict):
+                raise TypeError(f'2D Lidar {d} must be of type "dict"')
+            if 'model' not in d:
+                raise ValueError(f'2D Lidar {d} does not have a "model" parameter')
         sensor_list = []
         for d in value:
             sensor = Lidar2D(d['model'])
@@ -469,12 +482,13 @@ class SensorConfig(BaseConfig):
 
     @lidar3d.setter
     def lidar3d(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            'Sensors must be list of "dict"')
-        assert all([isinstance(d, dict) for d in value]), (  # noqa: C419
-            'Sensors must be list of "dict"')
-        assert all(['model' in d for d in value]), (  # noqa: C419
-            'Sensor "dict" must have "model" key')
+        if not isinstance(value, list):
+            raise TypeError(f'3D Lidars must be list of "dict". Got {value}')
+        for d in value:
+            if not isinstance(d, dict):
+                raise TypeError(f'3D Lidar {d} must be of type "dict"')
+            if 'model' not in d:
+                raise ValueError(f'3D Lidar {d} does not have a "model" parameter')
         sensor_list = []
         for d in value:
             sensor = Lidar3D(d['model'])
@@ -492,15 +506,13 @@ class SensorConfig(BaseConfig):
 
     @ins.setter
     def ins(self, value: List[dict]) -> None:
-        assert isinstance(value, list), (
-            'Sensors must be list of "dict"'
-        )
-        assert all([isinstance(d, dict) for d in value]), (  # noqa: C419
-            'Sensors must be list of "dict"'
-        )
-        assert all(['model' in d for d in value]), (  # noqa: C419
-            'Sensor "dict" must have "model" key'
-        )
+        if not isinstance(value, list):
+            raise TypeError(f'INS must be list of "dict". Got {value}')
+        for d in value:
+            if not isinstance(d, dict):
+                raise TypeError(f'INS {d} must be of type "dict"')
+            if 'model' not in d:
+                raise ValueError(f'INS {d} does not have a "model" parameter')
         sensor_list = []
         for d in value:
             sensor = INS(d['model'])
@@ -545,9 +557,8 @@ class SensorConfig(BaseConfig):
             xyz: List[float] = Accessory.XYZ,
             rpy: List[float] = Accessory.RPY
             ) -> None:
-        assert lidar2d or model, (
-            'Lidar2D object or model must be passed.'
-        )
+        if not (lidar2d or model):
+            raise ValueError('Lidar2D object or model must be passed')
         if not lidar2d and model:
             lidar2d = Lidar2D(model)
             lidar2d.set_frame_id(frame_id)
@@ -592,9 +603,8 @@ class SensorConfig(BaseConfig):
                 xyz=xyz,
                 rpy=rpy
             )
-        assert isinstance(ust, HokuyoUST), (
-            'Lidar2D object must be of type UST'
-        )
+        if not isinstance(ust, HokuyoUST):
+            raise TypeError(f'Lidar2D object must be of type UST. Received {type(ust)}')
         self._lidar2d.add(ust)
 
     # Lidar2D: Add LMS1xx
@@ -627,9 +637,8 @@ class SensorConfig(BaseConfig):
                 xyz=xyz,
                 rpy=rpy
             )
-        assert isinstance(lms1xx, SickLMS1XX), (
-            'Lidar2D object must be of type LMS1XX'
-        )
+        if not isinstance(lms1xx, SickLMS1XX):
+            raise TypeError(f'Lidar2D object must be of type LMS1XX. Received {type(lms1xx)}')
         self._lidar2d.add(lms1xx)
 
     # Lidar2D: Remove Lidar2D by passing object or index
@@ -685,9 +694,8 @@ class SensorConfig(BaseConfig):
             xyz: List[float] = Accessory.XYZ,
             rpy: List[float] = Accessory.RPY
             ) -> None:
-        assert lidar3d or model, (
-            'Lidar3D object or model must be passed.'
-        )
+        if not (lidar3d or model):
+            raise ValueError('Lidar3D object or model must be passed.')
         if not lidar3d and model:
             lidar3d = Lidar3D(model)
             lidar3d.set_frame_id(frame_id)
@@ -728,9 +736,10 @@ class SensorConfig(BaseConfig):
                 xyz=xyz,
                 rpy=rpy
             )
-        assert isinstance(velodyne, VelodyneLidar), (
-            'Lidar3D object must be of type VelodyneLidar'
-        )
+        if not isinstance(velodyne, VelodyneLidar):
+            raise TypeError(
+                f'Lidar3D object must be of type VelodyeLidar. Received {type(velodyne)}'
+            )
         self._lidar3d.add(velodyne)
 
     # Lidar3D: Remove Lidar3D by passing object or index
@@ -786,9 +795,8 @@ class SensorConfig(BaseConfig):
             xyz: List[float] = Accessory.XYZ,
             rpy: List[float] = Accessory.RPY
             ) -> None:
-        assert camera or model, (
-            'Camera object or model must be passed.'
-        )
+        if not (camera or model):
+            raise ValueError('Camera object or model must be passed.')
         if not camera and model:
             camera = Camera(model)
             camera.fps = fps
@@ -829,9 +837,8 @@ class SensorConfig(BaseConfig):
                 xyz=xyz,
                 rpy=rpy,
             )
-        assert isinstance(blackfly, FlirBlackfly), (
-            'Blackfly object must be of type Blackfly'
-        )
+        if not isinstance(blackfly, FlirBlackfly):
+            raise TypeError(f'Blackfly object must be of type Blackfly. Received {type(blackfly)}')
         self._camera.add(blackfly)
 
     # Camera: Add Realsense
@@ -878,9 +885,10 @@ class SensorConfig(BaseConfig):
                 xyz=xyz,
                 rpy=rpy,
             )
-        assert isinstance(realsense, IntelRealsense), (
-            'Realsense object must be of type Realsense'
-        )
+        if not isinstance(realsense, IntelRealsense):
+            raise TypeError(
+                f'Realsense object must be of type IntelRealsense. Received {type(realsense)}'
+            )
         self._camera.add(realsense)
 
     # Camera: Remove
@@ -936,9 +944,8 @@ class SensorConfig(BaseConfig):
             xyz: List[float] = Accessory.XYZ,
             rpy: List[float] = Accessory.RPY
             ) -> None:
-        assert imu or model, (
-            'IMU object or model must be passed.'
-        )
+        if not (imu or model):
+            raise ValueError('IMU object or model must be passed.')
         if not imu and model:
             imu = InertialMeasurementUnit(model)
             imu.set_frame_id(frame_id)
@@ -977,9 +984,8 @@ class SensorConfig(BaseConfig):
                 xyz=xyz,
                 rpy=rpy
             )
-        assert isinstance(imu, Microstrain), (
-            'IMU object must be of type Microstrain'
-        )
+        if not isinstance(imu, Microstrain):
+            raise TypeError(f'IMU object must be of type Microstrain. Received {type(imu)}')
         self._imu.add(imu)
 
     # IMU: Remove IMU by passing object or index
@@ -1030,9 +1036,8 @@ class SensorConfig(BaseConfig):
             xyz: List[float] = Accessory.XYZ,
             rpy: List[float] = Accessory.RPY
             ) -> None:
-        assert gps or model, (
-            'GPS object or model must be passed.'
-        )
+        if not (gps or model):
+            raise ValueError('GPS object or model must be passed.')
         if not gps and model:
             gps = GlobalPositioningSystem(model)
             gps.set_frame_id(frame_id)
@@ -1069,9 +1074,8 @@ class SensorConfig(BaseConfig):
                 xyz=xyz,
                 rpy=rpy
             )
-        assert isinstance(duro, SwiftNavDuro), (
-            'GPS object must be of type UST'
-        )
+        if not isinstance(duro, SwiftNavDuro):
+            raise TypeError(f'GPS object must be of type SwiftNavDuro. Received {type(duro)}')
         self._gps.add(duro)
 
     # GPS: Remove GPS by passing object or index

--- a/clearpath_config/sensors/types/cameras.py
+++ b/clearpath_config/sensors/types/cameras.py
@@ -1449,7 +1449,7 @@ class AxisCamera(BaseCamera):
 
     @min_pan.setter
     def min_pan(self, pan: float) -> None:
-        if pan < pi or pan > pi:
+        if pan < -pi or pan > pi:
             raise ValueError(f'Min pan {pan} must be in range [-pi, pi]')
         self._min_pan = pan
 

--- a/clearpath_config/sensors/types/cameras.py
+++ b/clearpath_config/sensors/types/cameras.py
@@ -100,8 +100,10 @@ class Republisher():
     }
 
     def __new__(self, config: dict) -> None:
-        assert self.TYPE in config, f'Republisher must have "{self.TYPE}" specified'
-        assert config[self.TYPE] in self.TYPES, f'Republisher "{self.TYPE}" must be one of "{self.TYPES.keys()}"'  # noqa:E501
+        if self.TYPE not in config:
+            raise ValueError(f'Republisher {config} must have "{self.TYPE}" specified')
+        if config[self.TYPE] not in self.TYPES:
+            raise ValueError(f'Republisher "{self.TYPE}" must be one of "{self.TYPES.keys()}"')
         return self.TYPES[config[self.TYPE]](config)
 
 
@@ -210,10 +212,13 @@ class BaseCamera(BaseSensor):
 
     @republishers.setter
     def republishers(self, republishers: list) -> None:
-        assert isinstance(republishers, list), (
-            'Camera republishers must be a list of dictionaries')
-        assert all([isinstance(i, dict) for i in republishers]), (  # noqa: C419
-            'Camera republishers must be a list of dictionaries')
+        if not isinstance(republishers, list):
+            raise TypeError(
+                f'Camera republishers must be a list of dictionaries. Got {republishers}'
+            )
+        for i in republishers:
+            if not isinstance(i, dict):
+                raise TypeError(f'Republisher {i} must be of type "dict"')
         self._republishers = []
         for republisher in republishers:
             self._republishers.append(Republisher(republisher))
@@ -371,30 +376,28 @@ class IntelRealsense(BaseCamera):
     def clean_profile(profile: str | list) -> list:
         if isinstance(profile, str):
             profile = profile.split(',')
-            assert len(profile) == 3, (
-                'Profile "%s" is not three comma separated values')
+            if len(profile) != 3:
+                raise ValueError(f'Profile "{profile}" must be 3 comma separated values')
             try:
                 profile = [int(entry) for entry in profile]
             except ValueError:
-                raise AssertionError(
-                    'Profile "%s" cannot be cast to integer')
+                raise TypeError(f'Profile "{profile}" must be 3 integers')
         else:
-            assert len(profile) == 3, (
-                'Profile "%s" is not three integer values')
-            assert all([isinstance(entry, int) for entry in profile]), (  # noqa: C419
-                'Profile "%s" is not three integer values')
+            if len(profile) != 3:
+                raise ValueError(f'Profile "{profile}" must be 3 integers')
+            for entry in profile:
+                if not isinstance(entry, int):
+                    raise TypeError(f'Profile {profile} contains {entry}, which must be an int')
         return profile
 
     def assert_pixel_length(
             self,
             length: int
             ) -> None:
-        assert isinstance(length, int), (
-            'Pixel value must be integer'
-        )
-        assert length >= 0, (
-            'Pixel length must be positive'
-        )
+        if not isinstance(length, int):
+            raise TypeError(f'Pixel value {length} must be integer')
+        if length < 0:
+            raise ValueError(f'Pixel length {length} must be positive')
 
     @property
     def device_type(self) -> str:
@@ -402,12 +405,10 @@ class IntelRealsense(BaseCamera):
 
     @device_type.setter
     def device_type(self, device_type: str) -> None:
-        assert device_type in self.DEVICE_TYPES, (
-            'Device type "%s" is not one of "%s"' % (
-                device_type,
-                self.DEVICE_TYPES
+        if device_type not in self.DEVICE_TYPES:
+            raise ValueError(
+                f'Device type "{device_type}" must be one of "{self.DEVICE_TYPES}"'
             )
-        )
         self._device_type = device_type
 
     @property
@@ -656,7 +657,8 @@ class FlirBlackfly(BaseCamera):
 
     @connection_type.setter
     def connection_type(self, _type: str) -> None:
-        assert _type in FlirBlackfly.CONNECTION_TYPES
+        if _type not in FlirBlackfly.CONNECTION_TYPES:
+            raise ValueError(f'Connection type {_type} must be one of {FlirBlackfly.CONNECTION_TYPES}')  # noqa: E501
         self._connection_type = _type
 
     @property
@@ -665,11 +667,10 @@ class FlirBlackfly(BaseCamera):
 
     @encoding.setter
     def encoding(self, encoding: str) -> None:
-        assert encoding in FlirBlackfly.ENCODINGS, (
-            'Encoding "%s" not found in support encodings: "%s"' % (
-                encoding, FlirBlackfly.ENCODINGS
+        if encoding not in FlirBlackfly.ENCODINGS:
+            raise ValueError(
+                f'Encoding "{encoding}" must be one of {FlirBlackfly.ENCODINGS}'
             )
-        )
         self._encoding = encoding
 
 
@@ -797,12 +798,10 @@ class StereolabsZed(BaseCamera):
 
     @device_type.setter
     def device_type(self, device_type: str) -> None:
-        assert device_type in self.DEVICE_TYPES, (
-            'Device type "%s" is not one of "%s"' % (
-                device_type,
-                self.DEVICE_TYPES
+        if device_type not in self.DEVICE_TYPES:
+            raise ValueError(
+                f'Device type "{device_type}" must be one of {self.DEVICE_TYPES}'
             )
-        )
         self._device_type = device_type
 
     @property
@@ -811,12 +810,10 @@ class StereolabsZed(BaseCamera):
 
     @resolution.setter
     def resolution(self, resolution: str) -> None:
-        assert resolution in self.RESOLUTION_PRESETS, (
-            'Resolution preset "%s" is not one oserial_numberf "%s"' % (
-                resolution,
-                self.RESOLUTION_PRESETS
+        if resolution not in self.RESOLUTION_PRESETS:
+            raise ValueError(
+                f'Resolution preset "{resolution}" must be one of {self.RESOLUTION_PRESETS}'
             )
-        )
         self._resolution = resolution
 
     @property
@@ -960,12 +957,10 @@ class LuxonisOAKD(BaseCamera):
 
     @device_type.setter
     def device_type(self, device_type: str) -> None:
-        assert device_type in self.DEVICE_TYPES, (
-            'Device type "%s" is not one of "%s"' % (
-                device_type,
-                self.DEVICE_TYPES
+        if device_type not in self.DEVICE_TYPES:
+            raise ValueError(
+                f'Device type "{device_type}" must be one of {self.DEVICE_TYPES}'
             )
-        )
         self._device_type = device_type
 
     @property
@@ -1344,12 +1339,10 @@ class AxisCamera(BaseCamera):
 
     @device_type.setter
     def device_type(self, device_type: str) -> None:
-        assert device_type in self.DEVICE_TYPES, (
-            'Device type "%s" is not one of "%s"' % (
-                device_type,
-                self.DEVICE_TYPES
+        if device_type not in self.DEVICE_TYPES:
+            raise ValueError(
+                f'Device type "{device_type}" must be one of {self.DEVICE_TYPES}'
             )
-        )
         self._device_type = device_type
 
     @property
@@ -1374,9 +1367,8 @@ class AxisCamera(BaseCamera):
 
     @http_port.setter
     def http_port(self, port: int) -> None:
-        assert port >= 0 and port <= 65535, (
-            f'Port {port} must be in range [0, 65535]'
-        )
+        if port < 0 or port > 65535:
+            raise ValueError(f'HTTP port {port} must be in range [0, 65535]')
         self._http_port = port
 
     @property
@@ -1393,7 +1385,8 @@ class AxisCamera(BaseCamera):
 
     @username.setter
     def username(self, username: str) -> None:
-        assert len(username) > 0, 'Username cannot be empty'
+        if len(username) <= 0:
+            raise ValueError('Username cannot be empty')
         self._username = username
 
     @property
@@ -1418,7 +1411,8 @@ class AxisCamera(BaseCamera):
 
     @camera.setter
     def camera(self, num: int) -> None:
-        assert num >= 0, f'Camera number {num} cannot be negative'
+        if num < 0:
+            raise ValueError(f'Camera number {num} cannot be negative')
         self._camera = num
 
     @property
@@ -1427,7 +1421,8 @@ class AxisCamera(BaseCamera):
 
     @width.setter
     def width(self, width: int) -> None:
-        assert width > 0, f'Frame width {width} must be positive'
+        if width <= 0:
+            raise ValueError(f'Frame width {width} must be positive')
         self._width = width
 
     @property
@@ -1436,7 +1431,8 @@ class AxisCamera(BaseCamera):
 
     @height.setter
     def height(self, height: int) -> None:
-        assert height > 0, f'Frame height {height} must be positive'
+        if height <= 0:
+            raise ValueError(f'Frame height {height} must be positive')
         self._height = height
 
     @property
@@ -1453,7 +1449,8 @@ class AxisCamera(BaseCamera):
 
     @min_pan.setter
     def min_pan(self, pan: float) -> None:
-        assert pan >= -pi and pan <= pi, f'Min pan {pan} must be in range [-pi, pi]'
+        if pan < pi or pan > pi:
+            raise ValueError(f'Min pan {pan} must be in range [-pi, pi]')
         self._min_pan = pan
 
     @property
@@ -1462,7 +1459,8 @@ class AxisCamera(BaseCamera):
 
     @max_pan.setter
     def max_pan(self, pan: float) -> None:
-        assert pan >= -pi and pan <= pi, f'Max pan {pan} must be in range [-pi, pi]'
+        if pan < -pi or pan > pi:
+            raise ValueError(f'Max pan {pan} must be in range [-pi, pi]')
         self._max_pan = pan
 
     @property
@@ -1471,7 +1469,8 @@ class AxisCamera(BaseCamera):
 
     @min_tilt.setter
     def min_tilt(self, tilt: float) -> None:
-        assert tilt >= -pi/2 and tilt <= pi/2, f'Min tilt {tilt} must be in range [-pi/2, pi/2]'
+        if tilt < -pi/2 or tilt > pi/2:
+            raise ValueError(f'Min tilt {tilt} must be in range [-pi/2, pi/2]')
         self._min_tilt = tilt
 
     @property
@@ -1480,7 +1479,8 @@ class AxisCamera(BaseCamera):
 
     @max_tilt.setter
     def max_tilt(self, tilt: float) -> None:
-        assert tilt >= -pi/2 and tilt <= pi/2, f'Max tilt {tilt} must be in range [-pi/2, pi/2]'
+        if tilt < -pi/2 or tilt > pi/2:
+            raise ValueError(f'Max tilt {tilt} must be in range [-pi/2, pi/2]')
         self._max_tilt = tilt
 
     @property
@@ -1489,7 +1489,8 @@ class AxisCamera(BaseCamera):
 
     @min_zoom.setter
     def min_zoom(self, zoom: float) -> None:
-        assert zoom > 0, f'Min zoom {zoom} must be positive'
+        if zoom <= 0:
+            raise ValueError(f'Min zoom {zoom} must be positive')
         self._min_zoom = zoom
 
     @property
@@ -1498,7 +1499,8 @@ class AxisCamera(BaseCamera):
 
     @max_zoom.setter
     def max_zoom(self, zoom: float) -> None:
-        assert zoom > 0, f'Max zoom {zoom} must be positive'
+        if zoom <= 0:
+            raise ValueError(f'Max zoom {zoom} must be positive')
         self._max_zoom = zoom
 
     @property
@@ -1507,7 +1509,8 @@ class AxisCamera(BaseCamera):
 
     @max_pan_speed.setter
     def max_pan_speed(self, speed: float) -> None:
-        assert speed > 0, f'Max pan speed {speed} must be positive'
+        if speed <= 0:
+            raise ValueError(f'Max pan speed {speed} must be positive')
         self._max_pan_speed = speed
 
     @property
@@ -1516,7 +1519,8 @@ class AxisCamera(BaseCamera):
 
     @max_tilt_speed.setter
     def max_tilt_speed(self, speed: float) -> None:
-        assert speed > 0, f'Max tilt speed {speed} must be positive'
+        if speed <= 0:
+            raise ValueError(f'Max tilt speed {speed} must be positive')
         self._max_tilt_speed = speed
 
     @property

--- a/clearpath_config/sensors/types/gps.py
+++ b/clearpath_config/sensors/types/gps.py
@@ -301,8 +301,10 @@ class MicrostrainGQ7(BaseGPS):
 
     @baud.setter
     def baud(self, baud: int) -> None:
-        assert isinstance(baud, int), ('Baud must be of type "int".')
-        assert baud >= 0, ('Baud must be positive integer.')
+        if not isinstance(baud, int):
+            raise TypeError(f'Baud {baud} must be of type "int".')
+        if baud < 0:
+            raise ValueError(f'Baud {baud} must be positive.')
         self._baud = baud
 
     def has_imu(self) -> bool:
@@ -399,8 +401,10 @@ class NMEA(BaseGPS):
 
     @baud.setter
     def baud(self, baud: int) -> None:
-        assert isinstance(baud, int), ('Baud must be of type "int".')
-        assert baud >= 0, ('Baud must be positive integer.')
+        if not isinstance(baud, int):
+            raise TypeError(f'Baud {baud} must be of type "int".')
+        if baud < 0:
+            raise ValueError(f'Baud {baud} must be positive.')
         self._baud = baud
 
 

--- a/clearpath_config/sensors/types/imu.py
+++ b/clearpath_config/sensors/types/imu.py
@@ -98,10 +98,10 @@ class IMUFilter():
     }
 
     def __new__(self, config: dict) -> None:
-        assert self.TYPE in config, (
-            f'IMU filter must have "{self.TYPE}" specified.')
-        assert config[self.TYPE] in self.TYPES, (
-            f'IMU filter "{self.TYPE}" must be one of: "{self.TYPES}"')
+        if self.TYPE not in config:
+            raise ValueError(f'IMU filter {config} does not have parameter "{self.TYPE}"')
+        if config[self.TYPE] not in self.TYPES:
+            raise ValueError(f'IMU filter {config} "{self.TYPE}" must be one of: "{self.TYPES}"')
         return self.TYPES[config[self.TYPE]](config)
 
 

--- a/clearpath_config/sensors/types/ins.py
+++ b/clearpath_config/sensors/types/ins.py
@@ -74,7 +74,8 @@ class InsAntenna(Accessory):
 
     @antenna_type.setter
     def antenna_type(self, antenna_type: str) -> None:
-        assert antenna_type in InsAntenna.TYPES, f'{antenna_type} is not one of ({InsAntenna.TYPES})'  # noqa: E501
+        if antenna_type not in InsAntenna.TYPES:
+            raise TypeError(f'{antenna_type} is not one of ({InsAntenna.TYPES})')
         self._antenna_type = antenna_type
 
 
@@ -169,8 +170,10 @@ class BaseINS(BaseSensor):
         self._antennas = []
         for a in antennas:
             self._antennas.append(a)
-        assert len(self.antennas) >= 1, 'Must include at least 1 antenna'
-        assert len(self.antennas) <= 2, 'Cannot have more than 2 antennas'
+        if len(self.antennas) < 1:
+            raise ValueError('INS must include at least 1 antenna')
+        if len(self.antennas) > 2:
+            raise ValueError('INS cannot have more than 2 antennas')
 
     @property
     def frame_id(self) -> str:
@@ -287,9 +290,10 @@ class Fixposition(BaseINS):
 
     @device_type.setter
     def device_type(self, device_type: str) -> None:
-        assert device_type in self.DEVICE_TYPES, (
-            f'Device type "{device_type}" is not one of "{self.DEVICE_TYPES}"'
-        )
+        if device_type not in self.DEVICE_TYPES:
+            raise ValueError(
+                f'Device type "{device_type}" is not one of "{self.DEVICE_TYPES}"'
+            )
         self._device_type = device_type
 
     @property
@@ -323,7 +327,8 @@ class Fixposition(BaseINS):
 
     @rate.setter
     def rate(self, rate: int) -> None:
-        assert rate >= 0, 'Rate cannot be negative'
+        if rate < 0:
+            raise ValueError(f'Rate {rate} must be positive')
         self._rate = rate
 
     @property
@@ -332,7 +337,8 @@ class Fixposition(BaseINS):
 
     @reconnect.setter
     def reconnect(self, reconnect: int) -> None:
-        assert reconnect >= 0, 'Reconnect timeout cannot be negative'
+        if reconnect < 0:
+            raise ValueError(f'Reconnect timeout {reconnect} must be positive')
         self._reconnect = reconnect
 
     @property

--- a/clearpath_config/sensors/types/lidars_3d.py
+++ b/clearpath_config/sensors/types/lidars_3d.py
@@ -334,7 +334,7 @@ class OusterOS1(BaseLidar3D):
 
     @base_type.setter
     def base_type(self, base: str) -> None:
-        if  base not in self.BASE_TYPES:
+        if base not in self.BASE_TYPES:
             raise ValueError(f'Base type {base} must be one of {self.BASE_TYPES}')
         self._base_type = base
 
@@ -418,7 +418,7 @@ class SeyondLidar(BaseLidar3D):
 
     @device_type.setter
     def device_type(self, device_type: str) -> None:
-        if  device_type not in self.DEVICE_TYPES:
+        if device_type not in self.DEVICE_TYPES:
             raise ValueError(
                 f'Device type "{device_type}" is not one of "{self.DEVICE_TYPES}"'
             )

--- a/clearpath_config/sensors/types/lidars_3d.py
+++ b/clearpath_config/sensors/types/lidars_3d.py
@@ -236,12 +236,10 @@ class VelodyneLidar(BaseLidar3D):
 
     @device_type.setter
     def device_type(self, device_type) -> None:
-        assert device_type in self.DEVICE_TYPES, (
-            'Device type "%s" is not one of "%s"' % (
-                device_type,
-                self.DEVICE_TYPES
+        if device_type not in self.DEVICE_TYPES:
+            raise ValueError(
+                f'Device type "{device_type}" must be one of {self.DEVICE_TYPES}'
             )
-        )
         self._device_type = device_type
 
 
@@ -336,7 +334,8 @@ class OusterOS1(BaseLidar3D):
 
     @base_type.setter
     def base_type(self, base: str) -> None:
-        assert base in self.BASE_TYPES, f'Base type {base} must be one of {self.BASE_TYPES}'
+        if  base not in self.BASE_TYPES:
+            raise ValueError(f'Base type {base} must be one of {self.BASE_TYPES}')
         self._base_type = base
 
     @property
@@ -345,7 +344,8 @@ class OusterOS1(BaseLidar3D):
 
     @cap_type.setter
     def cap_type(self, cap):
-        assert cap in self.CAP_TYPES, f'Cap type {cap} must be one of {self.CAP_TYPES}'
+        if cap not in self.CAP_TYPES:
+            raise ValueError(f'Cap type {cap} must be one of {self.CAP_TYPES}')
         self._cap_type = cap
 
 
@@ -418,7 +418,8 @@ class SeyondLidar(BaseLidar3D):
 
     @device_type.setter
     def device_type(self, device_type: str) -> None:
-        assert device_type in self.DEVICE_TYPES, (
-            f'Device type "{device_type}" is not one of "{self.DEVICE_TYPES}"'
-        )
+        if  device_type not in self.DEVICE_TYPES:
+            raise ValueError(
+                f'Device type "{device_type}" is not one of "{self.DEVICE_TYPES}"'
+            )
         self._device_type = device_type

--- a/clearpath_config/system/bash.py
+++ b/clearpath_config/system/bash.py
@@ -81,8 +81,10 @@ class BashConfig(BaseConfig):
     def additional_sources(self, sources: List[str]) -> None:
         self._source.clear()
         for f in sources:
-            assert isinstance(f, str), f'Bash source {f} must be a string'
-            assert os.path.exists(f), f'Bash source {f} does not exist'
+            if not isinstance(f, str):
+                raise TypeError(f'Bash source {f} must be a string')
+            if not os.path.exists(f):
+                raise FileNotFoundError(f'Bash source {f} does not exist')
             self._source.append(f)
 
     @property
@@ -93,5 +95,6 @@ class BashConfig(BaseConfig):
     def additional_envars(self, envars: dict) -> None:
         self._env.clear()
         for env in envars:
-            assert isinstance(env, str), f'Environment variable {env} must be a string'
+            if not isinstance(env, str):
+                raise TypeError(f'Environment variable {env}={envars[env]} must be a string')
             self._env[env] = str(envars[env])

--- a/clearpath_config/system/hosts.py
+++ b/clearpath_config/system/hosts.py
@@ -96,9 +96,10 @@ class HostConfig(BaseConfig):
         elif isinstance(value, Hostname):
             self._hostname = value
         else:
-            assert isinstance(value, str) or isinstance(value, Hostname), (
-                f'Hostname of {value} is invalid, must be of type "str" or "Hostname"'
-            )
+            if not (isinstance(value, str) or isinstance(value, Hostname)):
+                raise TypeError(
+                    f'Hostname of {value} is invalid, must be of type "str" or "Hostname"'
+                )
 
     # IP Address:
     # - the IP address at which the computer can be accessed
@@ -117,9 +118,10 @@ class HostConfig(BaseConfig):
         elif isinstance(value, IP):
             self._ip = value
         else:
-            assert isinstance(value, dict) or isinstance(value, IP), (
-                f'IP address of {value} is invalid, must be of type "str" or "IP"'
-            )
+            if not (isinstance(value, dict) or isinstance(value, IP)):
+                raise TypeError(
+                    f'IP address of {value} is invalid, must be of type "str" or "IP"'
+                )
 
 
 # HostListConfig

--- a/clearpath_config/system/middleware.py
+++ b/clearpath_config/system/middleware.py
@@ -137,9 +137,10 @@ class MiddlewareConfig(BaseConfig):
         elif isinstance(value, RMWImplementation):
             self._rmw_implementation = value
         else:
-            assert (isinstance(value, str)) or (isinstance(value, RMWImplementation)), (
-                f'RMW value of {value} is invalid, must be of type "str" or "RMWImplementation"'
-            )
+            if not (isinstance(value, str) or isinstance(value, RMWImplementation)):
+                raise TypeError(
+                    f'RMW value of {value} is invalid, must be of type "str" or "RMWImplementation"'  # noqa: E501
+                )
 
     @property
     def discovery(self) -> Discovery:
@@ -156,11 +157,10 @@ class MiddlewareConfig(BaseConfig):
         elif isinstance(value, Discovery):
             self._discovery = value
         else:
-            assert (
-                isinstance(value, str)) or (isinstance(value, Discovery)), (
-                f'Discovery mode value of {value} is invalid.'
-                f'Discovery mode must be of type "str" or "RMWImplementation"'
-            )
+            if not (isinstance(value, str) or isinstance(value, Discovery)):
+                raise TypeError(
+                    f'Discovery mode "{value}" must be of type "str" or "RMWImplementation"'
+                )
         self._discovery = value
 
     @property
@@ -179,9 +179,8 @@ class MiddlewareConfig(BaseConfig):
         :raises FileNotFoundError: if the specified path does not exist
         """
         # Check Type
-        assert isinstance(value, str), (
-            f'Middleware profile {value} is invalid, must be a string'
-        )
+        if not isinstance(value, str):
+            raise TypeError(f'Middleware profile {value} is invalid, must be a string')
         # Valid file
         if value != self.DEFAULTS[self.PROFILE]:
             if not os.path.exists(value):
@@ -199,8 +198,8 @@ class MiddlewareConfig(BaseConfig):
 
     @override_server_id.setter
     def override_server_id(self, value: bool) -> None:
-        assert isinstance(value, bool), (
-            f'Override server_id value of {value} is invalid, must be a boolean')
+        if not isinstance(value, bool):
+            raise TypeError(f'Override server_id value of {value} is invalid, must be a boolean')
         self._override_server_id = value
 
     @property
@@ -217,10 +216,10 @@ class MiddlewareConfig(BaseConfig):
         # Generate a list of ServerConfig Objects based on how the input was provided
         server_list = []
         if isinstance(value, list):
-            assert all([isinstance(i, dict) for i in value]), (  # noqa:C419
-                f'Server {value} is invalid, must be list of ' +
-                'type "dict" or of type "ServerListConfig"'
-            )
+            for i in value:
+                if not isinstance(i, dict):
+                    raise TypeError(f'Server {i} must be of type "dict"')
+
             # If the servers were not explicitly listed, assume every device in the hosts list
             # should have its own discovery server running
             if (not value) and (self.discovery == Discovery.SERVER):
@@ -228,39 +227,40 @@ class MiddlewareConfig(BaseConfig):
                 [value.append({ServerConfig.HOSTNAME: h.hostname}) for h in self.hosts.get_all()]
 
             for d in value:
-                assert isinstance(d, dict), (
-                    f'Server value of {d} is invalid, it must be of type "dict"'
-                )
+                if not isinstance(d, dict):
+                    raise TypeError(f'Server value of {d} is invalid, it must be of type "dict"')
                 server_list.append(ServerConfig(config=d))
-        else:
-            assert isinstance(value, ServerListConfig), (
-                f'Servers {value} is invalid, must be list of ' +
-                'type "dict" or of type "ServerListConfig"'
-            )
+        elif isinstance(value, ServerListConfig):
             server_list = value.get_all()
+        else:
+            raise TypeError(
+                f'Server list {value} must be of type "list[dict]" or "ServerListConfig", not "{type(value)}"'  # noqa: E501
+            )
 
         # set IP addresses based on the host names provided
         for server in server_list:
             # if a host name was provided, use the look up to determine the ip address
             if server.hostname:
-                assert any(server.hostname == s.hostname for s in self.hosts.get_all()), (
-                    f'Provided hostname: {server.hostname} is not listed in the hosts list'
-                )
+                if not any(server.hostname == s.hostname for s in self.hosts.get_all()):
+                    raise ValueError(
+                        f'Provided hostname: {server.hostname} is not listed in the hosts list'
+                    )
                 match = next((s for s in self.hosts.get_all() if s.hostname == server.hostname))
                 server.ip_address = match.ip_address
             else:
-                assert server.ip_address, (
-                    f'Server {server} is listed without a host name or IP address.'
-                )
+                if not server.ip_address:
+                    raise ValueError(
+                        f'Server {server} is listed without a host name or IP address.'
+                    )
 
         for server in server_list:
             # Ensure no duplicate server host/ip + port
             count = sum(((s.ip_address == server.ip_address) and (s.port == server.port))
                         for s in server_list)
-            assert count == 1, (
-                f'Discovery server {server} conflicts with another discovery server. ' +
-                'Each combination of host/ip and port number must be unique.'
-            )
+            if count != 1:
+                raise ValueError(
+                    f'Discovery server {server} conflicts with another discovery server. Each combination of host/ip and port number must be unique.'  # noqa: E501
+                )
 
         # sort the servers by host/ip address and then port
         # required for consistent server id numbering
@@ -276,10 +276,10 @@ class MiddlewareConfig(BaseConfig):
             # (unspecified ones will default and show up as duplicates)
             for server in server_list:
                 count = sum(s.server_id == server.server_id for s in server_list)
-                assert count == 1, (
-                    f'Server {server} does not have a unique server id. While ' +
-                    'override_server_id is true, each server must have a unique id specified.'
-                )
+                if count != 1:
+                    raise ValueError(
+                        f'Server {server} does not have a unique server id. While override_server_id is true, each server must have a unique id specified.'  # noqa: E501
+                    )
 
         servers = ServerListConfig()
         servers.set_all(server_list)
@@ -303,8 +303,12 @@ class MiddlewareConfig(BaseConfig):
             value = 'off'
 
         # Check Type is valid
-        assert isinstance(value, str), f'Automatic discovery range {value} must be a string'
-        assert value.lower() in self.DISCOVERY_RANGES, f'Automatic discovery range {value} must be one of {self.DISCOVERY_RANGES}'  # noqa: E501
+        if not isinstance(value, str):
+            raise TypeError(f'Automatic discovery range {value} must be a string')
+        if value.lower() not in self.DISCOVERY_RANGES:
+            raise ValueError(
+                f'Automatic discovery range {value} must be one of {self.DISCOVERY_RANGES}'
+            )
 
         self._automatic_discovery_range = value.lower()
         return
@@ -321,7 +325,8 @@ class MiddlewareConfig(BaseConfig):
     def static_peers(self, value: List[str]) -> None:
         # check all peers are strings
         for s in value:
-            assert isinstance(s, str), f'Invalid static peer: {s}. Value must be a string.'
+            if not isinstance(s, str):
+                raise TypeError(f'Invalid static peer: {s}. Value must be a string.')
 
         arr = list(value)  # make a copy of the array to assign
         self._static_peers = arr

--- a/clearpath_config/system/middleware.py
+++ b/clearpath_config/system/middleware.py
@@ -173,15 +173,19 @@ class MiddlewareConfig(BaseConfig):
 
     @profile.setter
     def profile(self, value: str) -> None:
+        """
+        Set the path to the middleware profile file.
+
+        :raises FileNotFoundError: if the specified path does not exist
+        """
         # Check Type
         assert isinstance(value, str), (
             f'Middleware profile {value} is invalid, must be a string'
         )
         # Valid file
         if value != self.DEFAULTS[self.PROFILE]:
-            assert os.path.exists(value), (
-                f'Middleware profile path {value} does not exist'
-            )
+            if not os.path.exists(value):
+                raise FileNotFoundError(f'Middleware profile path {value} does not exist')
         self._profile = value
         return
 

--- a/clearpath_config/system/servers.py
+++ b/clearpath_config/system/servers.py
@@ -100,13 +100,11 @@ class ServerConfig(BaseConfig):
     @server_id.setter
     def server_id(self, value: int) -> None:
         # Check Type
-        assert isinstance(value, int), (
-            f'Remote Server ID {value} is invalid, must be an integer'
-        )
+        if not isinstance(value, int):
+            raise TypeError(f'Remote Server ID {value} is invalid, must be an integer')
         # [0-255] Range
-        assert 0 <= value < 255, (
-            f'Discovery Server ID {value} is invalid, must be in range 0 - 254'
-        )
+        if value < 0 or value > 255:
+            raise ValueError(f'Discovery Server ID {value} is invalid, must be in range 0 - 255')
         self._server_id = value
         return
 
@@ -127,9 +125,10 @@ class ServerConfig(BaseConfig):
         elif isinstance(value, Hostname):
             self._hostname = value
         else:
-            assert isinstance(value, str) or isinstance(value, Hostname), (
-                f'Hostname of {value} is invalid, must be of type "str" or "Hostname"'
-            )
+            if not (isinstance(value, str) or isinstance(value, Hostname)):
+                raise TypeError(
+                    f'Hostname of {value} is invalid, must be of type "str" or "Hostname"'
+                )
         return
 
     @property
@@ -149,9 +148,10 @@ class ServerConfig(BaseConfig):
         elif isinstance(value, IP):
             self._ip_address = value
         else:
-            assert isinstance(value, dict) or isinstance(value, IP), (
-                f'IP address of {value} is invalid, must be of type "str" or "IP"'
-            )
+            if not (isinstance(value, dict) or isinstance(value, IP)):
+                raise TypeError(
+                    f'IP address of {value} is invalid, must be of type "str" or "IP"'
+                )
         return
 
     @property
@@ -169,9 +169,10 @@ class ServerConfig(BaseConfig):
         elif isinstance(value, Port):
             self._port = value
         else:
-            assert isinstance(value, dict) or isinstance(value, Port), (
-                f'Port of {value} is invalid, must be of type "str" or "Port"'
-            )
+            if not (isinstance(value, dict) or isinstance(value, Port)):
+                raise TypeError(
+                    f'Port of {value} is invalid, must be of type "str" or "Port"'
+                )
         return
 
     @property
@@ -185,9 +186,8 @@ class ServerConfig(BaseConfig):
     @enabled.setter
     def enabled(self, value: bool) -> None:
         # Check Type
-        assert (isinstance(value, bool)), (
-            f'Enabled {value} is invalid, must be a boolean'
-        )
+        if not (isinstance(value, bool)):
+            raise TypeError(f'Enabled {value} is invalid, must be a boolean')
         self._enabled = value
         return
 

--- a/clearpath_config/system/system.py
+++ b/clearpath_config/system/system.py
@@ -155,29 +155,28 @@ class SystemConfig(BaseConfig):
         host_list = []
         if isinstance(value, list):
             for d in value:
-                assert isinstance(d, dict), (
-                    f'Host value of {d} is invalid, it must be of type "dict"'
-                )
+                if not isinstance(d, dict):
+                    raise TypeError(f'Host value of {d} is invalid, it must be of type "dict"')
                 host_list.append(HostConfig(config=d))
 
             for host in host_list:
                 # Ensure no duplicate hostname or IP
                 count = sum(((host.ip_address == h.ip_address) or (host.hostname == h.hostname))
                             for h in host_list)
-                assert count == 1, (
-                    f'Host {host} conflicts with another host. ' +
-                    'Each hostname and ip must be unique.'
-                )
+                if count != 1:
+                    raise ValueError(
+                        f'Host {host} conflicts with another host. Each hostname and ip must be unique.'  # noqa: E501
+                    )
 
             self._hosts = HostListConfig()
             self._hosts.set_all(host_list)
         elif isinstance(value, HostListConfig):
             self._hosts = value
         else:
-            assert isinstance(value, list) or isinstance(value, HostConfig), (
-                f'Hosts value of {value} is invalid, ' +
-                'it must be of type "List[dict]" or "HostListConfig"'
-            )
+            if not (isinstance(value, list) or isinstance(value, HostConfig)):
+                raise TypeError(
+                    f'Hosts value of {value} is invalid, it must be of type "List[dict]" or "HostListConfig"'  # noqa: E501
+                )
 
     @property
     def localhost(self) -> str:
@@ -189,9 +188,10 @@ class SystemConfig(BaseConfig):
 
     @localhost.setter
     def localhost(self, value: str | Hostname) -> None:
-        assert isinstance(value, str) or isinstance(value, Hostname), (
-            f'Localhost of {value} is invalid, must be of type "str" or "Hostname"'
-        )
+        if not (isinstance(value, str) or isinstance(value, Hostname)):
+            raise TypeError(
+                f'Localhost of {value} is invalid, must be of type "str" or "Hostname"'
+            )
         if isinstance(value, str):
             self._localhost = Hostname(value)
         elif isinstance(value, Hostname):
@@ -212,9 +212,8 @@ class SystemConfig(BaseConfig):
         elif isinstance(value, Username):
             self._username = value
         else:
-            assert isinstance(value, str) or isinstance(value, Username), (
-                'Username must be of type "str" or "Username"'
-            )
+            if not (isinstance(value, str) or isinstance(value, Username)):
+                raise TypeError(f'Username {value} must be of type "str" or "Username"')
 
     @property
     def namespace(self) -> str:
@@ -243,9 +242,8 @@ class SystemConfig(BaseConfig):
         elif isinstance(value, DomainID):
             self._domain_id = value
         else:
-            assert isinstance(value, int) or isinstance(value, DomainID), (
-                'Domain ID must be of type "int" or "DomainID"'
-            )
+            if not (isinstance(value, int) or isinstance(value, DomainID)):
+                raise TypeError(f'Domain ID {value} must be of type "int" or "DomainID"')
 
     @property
     def middleware(self) -> MiddlewareConfig:
@@ -264,10 +262,10 @@ class SystemConfig(BaseConfig):
         elif isinstance(value, MiddlewareConfig):
             self._middleware = value
         else:
-            assert isinstance(value, dict) or (
-                isinstance(value, MiddlewareConfig)), (
-                'Middleware configuration must be of type "dict" or "MiddlewareConfig"'
-            )
+            if not (isinstance(value, dict) or isinstance(value, MiddlewareConfig)):
+                raise TypeError(
+                    f'Middleware configuration {value} must be of type "dict" or "MiddlewareConfig"'  # noqa: E501
+                )
 
     @property
     def workspaces(self) -> list:
@@ -275,10 +273,11 @@ class SystemConfig(BaseConfig):
 
     @workspaces.setter
     def workspaces(self, value: list) -> None:
-        assert isinstance(value, list), (
-            'Workspaces must be "list" of "str"')
-        assert all([isinstance(i, str) for i in value]), (  # noqa:C419
-            'Workspaces must be "list" of "str"')
+        if not isinstance(value, list):
+            raise TypeError(f'Workspaces {value} must be "list" of "str"')
+        for i in value:
+            if not isinstance(i, str):
+                raise TypeError(f'Workspace {i} must be of type "str"')
         self._workspaces = value
 
     @property
@@ -295,5 +294,7 @@ class SystemConfig(BaseConfig):
         elif isinstance(bash, BashConfig):
             self._bash = bash
         else:
-            assert isinstance(bash, dict) or isinstance(bash, BashConfig), \
-                'Bash configuration must be of type "dict" or "BashConfig"'
+            if not (isinstance(bash, dict) or isinstance(bash, BashConfig)):
+                raise TypeError(
+                    f'Bash configuration {bash} must be of type "dict" or "BashConfig"'
+                )


### PR DESCRIPTION
Instead of using `assert` to validate data, raise appropriate exceptions (e.g. `FileNotFoundError`, `ValueError`, `TypeError`) with exception messages. This should help with debugging and produce clearer output when `robot.yaml` doesn't parse correctly.

See RPSW-2227