### PR TITLE
Changed to rostooling/setup-ros-docker:ubuntu-noble-latest for CI image.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,9 @@ jobs:
     name: Jazzy Clearpath Source
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:noble
+      image: rostooling/setup-ros-docker:ubuntu-noble-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: jazzy
       - uses: ros-tooling/action-ros-ci@v0.3
         id: action_ros_ci_step
         with:


### PR DESCRIPTION
This speeds up the CI since it pulls an image with ROS 2 Jazzy already installed.