### PR TITLE
Feature: Platform Configuration Class Rework

### DIFF
--- a/clearpath_config/clearpath_config.py
+++ b/clearpath_config/clearpath_config.py
@@ -30,7 +30,7 @@ from clearpath_config.common.utils.yaml import read_yaml, write_yaml
 from clearpath_config.links.links import LinksConfig
 from clearpath_config.manipulators.manipulators import ManipulatorConfig
 from clearpath_config.mounts.mounts import MountsConfig
-from clearpath_config.platform.platform import PlatformConfig
+from clearpath_config.platform.platform import BasePlatformConfig
 from clearpath_config.sensors.sensors import SensorConfig
 from clearpath_config.system.system import SystemConfig
 
@@ -66,7 +66,7 @@ class ClearpathConfig(BaseConfig):
         SERIAL_NUMBER: 'generic',
         VERSION: 0,
         SYSTEM: SystemConfig.DEFAULTS,
-        PLATFORM: PlatformConfig.DEFAULTS,
+        PLATFORM: BasePlatformConfig.DEFAULTS,
         LINKS: LinksConfig.DEFAULTS,
         MANIPULATORS: ManipulatorConfig.DEFAULTS,
         MOUNTS: MountsConfig.DEFAULTS,
@@ -82,7 +82,7 @@ class ClearpathConfig(BaseConfig):
         # Initialization of Sub-Configs
         self._config = {}
         self._system = SystemConfig(self.DEFAULTS[self.SYSTEM])
-        self._platform = PlatformConfig(self.DEFAULTS[self.PLATFORM])
+        self._platform = BasePlatformConfig(self.DEFAULTS[self.PLATFORM])
         self._links = LinksConfig(self.DEFAULTS[self.LINKS])
         self._manipulators = ManipulatorConfig(self.DEFAULTS[self.MANIPULATORS])
         self._mounts = MountsConfig(self.DEFAULTS[self.MOUNTS])
@@ -155,7 +155,7 @@ class ClearpathConfig(BaseConfig):
         self._system.config = config
 
     @property
-    def platform(self) -> PlatformConfig:
+    def platform(self) -> BasePlatformConfig:
         self.set_config_param(
             self.PLATFORM,
             self._platform.config[self.PLATFORM])

--- a/clearpath_config/common/types/platform.py
+++ b/clearpath_config/common/types/platform.py
@@ -57,71 +57,47 @@ class IndexingProfile:
 
 
 # Platform
-# - all supported platforms
+# - registry of platform configurations
+# - concrete platform data is defined in BasePlatformConfig subclasses
+#   under clearpath_config.platform.definitions
 class Platform:
-    # Dingo D V1
-    DD100 = 'dd100'
-    # Dingo O V1
-    DO100 = 'do100'
-    # Dingo D V1.5
-    DD150 = 'dd150'
-    # Dingo D V1.5
-    DO150 = 'do150'
-    # Jackal V1
-    J100 = 'j100'
-    # Husky V2
-    A200 = 'a200'
-    # Husky V3
-    A300 = 'a300'
-    # Ridgeback V1
-    R100 = 'r100'
-    # Warthog V2
-    W200 = 'w200'
-    # Genric Robot
-    GENERIC = 'generic'
+    _REGISTRY = {}
+    _LOADED = False
 
-    ALL = [
-        DD100,
-        DO100,
-        DD150,
-        DO150,
-        J100,
-        A200,
-        A300,
-        R100,
-        W200,
-        GENERIC
-    ]
+    @classmethod
+    def register(cls, platform_config_cls) -> None:
+        """Register a concrete BasePlatformConfig subclass."""
+        cls._REGISTRY[platform_config_cls.NAME] = platform_config_cls
 
-    PACS = {
-        GENERIC: PACSProfile(rows=100, columns=100),
-        A200: PACSProfile(rows=8, columns=7),
-        A300: PACSProfile(rows=9, columns=5),
-        J100: PACSProfile(rows=4, columns=2),
-        W200: PACSProfile(rows=100, columns=100),
-        R100: PACSProfile(rows=100, columns=100),
-    }
+    @classmethod
+    def get(cls, name: str):
+        """Return the registered BasePlatformConfig subclass for the given name."""
+        cls._ensure_loaded()
+        if name not in cls._REGISTRY:
+            raise KeyError(
+                f'No platform registered for "{name}". '
+                f'Available: {list(cls._REGISTRY.keys())}'
+            )
+        return cls._REGISTRY[name]
 
-    INDEX = {
-        GENERIC: IndexingProfile(),
-        A200: IndexingProfile(),
-        A300: IndexingProfile(),
-        DD100: IndexingProfile(imu=1),
-        DO100: IndexingProfile(imu=1),
-        DD150: IndexingProfile(imu=1),
-        DO150: IndexingProfile(imu=1),
-        J100: IndexingProfile(gps=1, imu=1),
-        R100: IndexingProfile(imu=1),
-        W200: IndexingProfile(imu=1),
-    }
+    @classmethod
+    def all_names(cls) -> list:
+        """Return list of all registered platform names."""
+        cls._ensure_loaded()
+        return list(cls._REGISTRY.keys())
+
+    @classmethod
+    def _ensure_loaded(cls):
+        """Lazily import built-in platform definitions on first access."""
+        if cls._LOADED:
+            return
+        cls._LOADED = True
+        import clearpath_config.platform.definitions  # noqa: F401
 
     @staticmethod
     def assert_is_supported(platform):
         """
         Raise an exception if the platform is not presently supported/usable.
-
-        Unsupported platforms may become supported in a future release, and there are no plans
-        to remove it; it simply is not (yet) compatible with the current ROS release.
 
         @param platform  The platform-identifying serial number prefix (e.g. 'a200', 'j100')
 
@@ -134,8 +110,6 @@ class Platform:
     def notify_if_deprecated(platform):
         """
         Print a notification that the selected platform is deprecated.
-
-        Deprecated platforms may have their support removed in a future version
 
         @param platform  The platform-identifying serial number prefix (e.g. 'a200', 'j100')
         """

--- a/clearpath_config/common/types/serial_number.py
+++ b/clearpath_config/common/types/serial_number.py
@@ -68,22 +68,23 @@ class SerialNumber:
         # Mechanically both are effectively identical, and re-use the same options & payloads
         if sn_tokens[0] == 'a201':
             sn_tokens[0] = 'a200'
+        # Generic Robot (check before platform validation to avoid circular import
+        # at class-body time when BaseConfig._SERIAL_NUMBER = SerialNumber('generic'))
+        if sn_tokens[0] == 'generic':
+            if len(sn_tokens) > 1:
+                return (sn_tokens[0], sn_tokens[1])
+            else:
+                return (sn_tokens[0], 'e')
         # Match to Robot
-        if sn_tokens[0] not in Platform.ALL:
+        if sn_tokens[0] not in Platform.all_names():
             raise ValueError(
-                f'Serial number model entry {sn_tokens[0]} must be one of {Platform.ALL}'
+                f'Serial number model entry {sn_tokens[0]} must be one of {Platform.all_names()}'
             )
 
         # Verify that the platform is well-supported and not deprecated
         Platform.assert_is_supported(sn_tokens[0])
         Platform.notify_if_deprecated(sn_tokens[0])
 
-        # Generic Robot
-        if sn_tokens[0] == Platform.GENERIC:
-            if len(sn) > 1:
-                return (sn_tokens[0], sn[1])
-            else:
-                return (sn_tokens[0], 'xxxx')
         # Check Number
         if not sn_tokens[1].isdecimal():
             raise ValueError(f'Serial number unit entry "{sn_tokens[1]}" must be an integer')

--- a/clearpath_config/platform/attachments/a200.py
+++ b/clearpath_config/platform/attachments/a200.py
@@ -35,8 +35,7 @@ from clearpath_config.platform.types.bumper import Bumper
 
 
 class A200TopPlate(BaseAttachment):
-    PLATFORM = 'a200'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
+    TYPE = 'top_plate'
     DEFAULT = 'default'
     LARGE = 'large'
     PACS = 'pacs'
@@ -45,7 +44,7 @@ class A200TopPlate(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = PARENT,
@@ -56,8 +55,7 @@ class A200TopPlate(BaseAttachment):
 
 
 class A200Bumper(Bumper):
-    PLATFORM = 'a200'
-    ATTACHMENT_MODEL = '%s.bumper' % PLATFORM
+    TYPE = 'bumper'
     EXTENSION = 0.0
     DEFAULT = 'default'
     MODELS = [DEFAULT]
@@ -65,7 +63,7 @@ class A200Bumper(Bumper):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             extension: float = EXTENSION,
@@ -77,8 +75,7 @@ class A200Bumper(Bumper):
 
 
 class A200SensorArch(BaseAttachment):
-    PLATFORM = 'a200'
-    ATTACHMENT_MODEL = '%s.sensor_arch' % PLATFORM
+    TYPE = 'sensor_arch'
     ARCH_300 = 'sensor_arch_300'
     ARCH_510 = 'sensor_arch_510'
     DEFAULT = ARCH_300
@@ -87,7 +84,7 @@ class A200SensorArch(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = PARENT,
@@ -98,8 +95,7 @@ class A200SensorArch(BaseAttachment):
 
 
 class A200ObserverBackpack(BaseAttachment):
-    PLATFORM = 'a200'
-    ATTACHMENT_MODEL = '%s.observer_backpack' % PLATFORM
+    TYPE = 'observer_backpack'
     OBSERVER_BACKPACK = 'observer_backpack'
     MODELS = [OBSERVER_BACKPACK]
     DEFAULT = OBSERVER_BACKPACK
@@ -107,7 +103,7 @@ class A200ObserverBackpack(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = PARENT,
@@ -120,13 +116,13 @@ class A200ObserverBackpack(BaseAttachment):
 class A200Attachment(PlatformAttachment):
     PLATFORM = 'a200'
     # Top Plates
-    TOP_PLATE = A200TopPlate.ATTACHMENT_MODEL
+    TOP_PLATE = f'{PLATFORM}.{A200TopPlate.TYPE}'
     # Bumper
-    BUMPER = A200Bumper.ATTACHMENT_MODEL
+    BUMPER = f'{PLATFORM}.{A200Bumper.TYPE}'
     # Archs
-    SENSOR_ARCH = A200SensorArch.ATTACHMENT_MODEL
+    SENSOR_ARCH = f'{PLATFORM}.{A200SensorArch.TYPE}'
     # Observer Backpack
-    OBSERVER_BACKPACK = A200ObserverBackpack.ATTACHMENT_MODEL
+    OBSERVER_BACKPACK = f'{PLATFORM}.{A200ObserverBackpack.TYPE}'
 
     TYPES = {
         TOP_PLATE: A200TopPlate,

--- a/clearpath_config/platform/attachments/a200.py
+++ b/clearpath_config/platform/attachments/a200.py
@@ -29,13 +29,13 @@
 from typing import List
 
 from clearpath_config.common.types.accessory import Accessory
-from clearpath_config.common.types.platform import Platform
+
 from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
 from clearpath_config.platform.types.bumper import Bumper
 
 
 class A200TopPlate(BaseAttachment):
-    PLATFORM = Platform.A200
+    PLATFORM = 'a200'
     ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
     DEFAULT = 'default'
     LARGE = 'large'
@@ -56,7 +56,7 @@ class A200TopPlate(BaseAttachment):
 
 
 class A200Bumper(Bumper):
-    PLATFORM = Platform.A200
+    PLATFORM = 'a200'
     ATTACHMENT_MODEL = '%s.bumper' % PLATFORM
     EXTENSION = 0.0
     DEFAULT = 'default'
@@ -77,7 +77,7 @@ class A200Bumper(Bumper):
 
 
 class A200SensorArch(BaseAttachment):
-    PLATFORM = Platform.A200
+    PLATFORM = 'a200'
     ATTACHMENT_MODEL = '%s.sensor_arch' % PLATFORM
     ARCH_300 = 'sensor_arch_300'
     ARCH_510 = 'sensor_arch_510'
@@ -98,7 +98,7 @@ class A200SensorArch(BaseAttachment):
 
 
 class A200ObserverBackpack(BaseAttachment):
-    PLATFORM = Platform.A200
+    PLATFORM = 'a200'
     ATTACHMENT_MODEL = '%s.observer_backpack' % PLATFORM
     OBSERVER_BACKPACK = 'observer_backpack'
     MODELS = [OBSERVER_BACKPACK]
@@ -118,7 +118,7 @@ class A200ObserverBackpack(BaseAttachment):
 
 
 class A200Attachment(PlatformAttachment):
-    PLATFORM = Platform.A200
+    PLATFORM = 'a200'
     # Top Plates
     TOP_PLATE = A200TopPlate.ATTACHMENT_MODEL
     # Bumper

--- a/clearpath_config/platform/attachments/a300.py
+++ b/clearpath_config/platform/attachments/a300.py
@@ -29,13 +29,13 @@
 from typing import List
 
 from clearpath_config.common.types.accessory import Accessory
-from clearpath_config.common.types.platform import Platform
+
 from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
 from clearpath_config.platform.types.bumper import Bumper
 
 
 class A300TopPlate(BaseAttachment):
-    PLATFORM = Platform.A300
+    PLATFORM = 'a300'
     ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
     DEFAULT = 'default'
     PACS = 'pacs'
@@ -55,7 +55,7 @@ class A300TopPlate(BaseAttachment):
 
 
 class A300Bumper(Bumper):
-    PLATFORM = Platform.A300
+    PLATFORM = 'a300'
     ATTACHMENT_MODEL = '%s.bumper' % PLATFORM
     EXTENSION = 0.0
     DEFAULT = 'default'
@@ -76,7 +76,7 @@ class A300Bumper(Bumper):
 
 
 class A300WirelessCharger(BaseAttachment):
-    PLATFORM = Platform.A300
+    PLATFORM = 'a300'
     ATTACHMENT_MODEL = f'{PLATFORM}.wireless_charger'
     DEFAULT = 'default'
     MODELS = [DEFAULT]
@@ -95,7 +95,7 @@ class A300WirelessCharger(BaseAttachment):
 
 
 class A300AmpEnclosure(BaseAttachment):
-    PLATFORM = Platform.A300
+    PLATFORM = 'a300'
     ATTACHMENT_MODEL = f'{PLATFORM}.amp_enclosure'
     AMP_ENCLOSURE = 'amp_enclosure'
     MODELS = [AMP_ENCLOSURE]
@@ -115,7 +115,7 @@ class A300AmpEnclosure(BaseAttachment):
 
 
 class A300AmpSensorArch(BaseAttachment):
-    PLATFORM = Platform.A300
+    PLATFORM = 'a300'
     ATTACHMENT_MODEL = f'{PLATFORM}.amp_sensor_arch'
     AMP_SENSOR_ARCH = 'amp_sensor_arch'
     MODELS = [AMP_SENSOR_ARCH]
@@ -135,7 +135,7 @@ class A300AmpSensorArch(BaseAttachment):
 
 
 class A300Spotlight(BaseAttachment):
-    PLATFORM = Platform.A300
+    PLATFORM = 'a300'
     ATTACHMENT_MODEL = f'{PLATFORM}.spotlight'
     SPOTLIGHT = 'spotlight'
     MODELS = [SPOTLIGHT]
@@ -155,7 +155,7 @@ class A300Spotlight(BaseAttachment):
 
 
 class A300Attachment(PlatformAttachment):
-    PLATFORM = Platform.A300
+    PLATFORM = 'a300'
     # Top Plates
     TOP_PLATE = A300TopPlate.ATTACHMENT_MODEL
     # Bumper

--- a/clearpath_config/platform/attachments/a300.py
+++ b/clearpath_config/platform/attachments/a300.py
@@ -35,8 +35,7 @@ from clearpath_config.platform.types.bumper import Bumper
 
 
 class A300TopPlate(BaseAttachment):
-    PLATFORM = 'a300'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
+    TYPE = 'top_plate'
     DEFAULT = 'default'
     PACS = 'pacs'
     MODELS = [DEFAULT, PACS]
@@ -44,7 +43,7 @@ class A300TopPlate(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = PARENT,
@@ -55,8 +54,7 @@ class A300TopPlate(BaseAttachment):
 
 
 class A300Bumper(Bumper):
-    PLATFORM = 'a300'
-    ATTACHMENT_MODEL = '%s.bumper' % PLATFORM
+    TYPE = 'bumper'
     EXTENSION = 0.0
     DEFAULT = 'default'
     MODELS = [DEFAULT]
@@ -64,7 +62,7 @@ class A300Bumper(Bumper):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             extension: float = EXTENSION,
@@ -76,15 +74,14 @@ class A300Bumper(Bumper):
 
 
 class A300WirelessCharger(BaseAttachment):
-    PLATFORM = 'a300'
-    ATTACHMENT_MODEL = f'{PLATFORM}.wireless_charger'
+    TYPE = 'wireless_charger'
     DEFAULT = 'default'
     MODELS = [DEFAULT]
     PARENT = 'base_link'
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = PARENT,
@@ -95,8 +92,7 @@ class A300WirelessCharger(BaseAttachment):
 
 
 class A300AmpEnclosure(BaseAttachment):
-    PLATFORM = 'a300'
-    ATTACHMENT_MODEL = f'{PLATFORM}.amp_enclosure'
+    TYPE = 'amp_enclosure'
     AMP_ENCLOSURE = 'amp_enclosure'
     MODELS = [AMP_ENCLOSURE]
     DEFAULT = AMP_ENCLOSURE
@@ -104,7 +100,7 @@ class A300AmpEnclosure(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = PARENT,
@@ -115,8 +111,7 @@ class A300AmpEnclosure(BaseAttachment):
 
 
 class A300AmpSensorArch(BaseAttachment):
-    PLATFORM = 'a300'
-    ATTACHMENT_MODEL = f'{PLATFORM}.amp_sensor_arch'
+    TYPE = 'amp_sensor_arch'
     AMP_SENSOR_ARCH = 'amp_sensor_arch'
     MODELS = [AMP_SENSOR_ARCH]
     DEFAULT = AMP_SENSOR_ARCH
@@ -124,7 +119,7 @@ class A300AmpSensorArch(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = PARENT,
@@ -135,8 +130,7 @@ class A300AmpSensorArch(BaseAttachment):
 
 
 class A300Spotlight(BaseAttachment):
-    PLATFORM = 'a300'
-    ATTACHMENT_MODEL = f'{PLATFORM}.spotlight'
+    TYPE = 'spotlight'
     SPOTLIGHT = 'spotlight'
     MODELS = [SPOTLIGHT]
     DEFAULT = SPOTLIGHT
@@ -144,7 +138,7 @@ class A300Spotlight(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = PARENT,
@@ -157,16 +151,16 @@ class A300Spotlight(BaseAttachment):
 class A300Attachment(PlatformAttachment):
     PLATFORM = 'a300'
     # Top Plates
-    TOP_PLATE = A300TopPlate.ATTACHMENT_MODEL
+    TOP_PLATE = f'{PLATFORM}.{A300TopPlate.TYPE}'
     # Bumper
-    BUMPER = A300Bumper.ATTACHMENT_MODEL
+    BUMPER = f'{PLATFORM}.{A300Bumper.TYPE}'
     # Observer/AMP attachments
-    AMP_ENCLOSURE = A300AmpEnclosure.ATTACHMENT_MODEL
-    AMP_SENSOR_ARCH = A300AmpSensorArch.ATTACHMENT_MODEL
+    AMP_ENCLOSURE = f'{PLATFORM}.{A300AmpEnclosure.TYPE}'
+    AMP_SENSOR_ARCH = f'{PLATFORM}.{A300AmpSensorArch.TYPE}'
     # Spotlight
-    SPOTLIGHT = A300Spotlight.ATTACHMENT_MODEL
+    SPOTLIGHT = f'{PLATFORM}.{A300Spotlight.TYPE}'
     # Wireless charger
-    WIRELESS_CHARGER = A300WirelessCharger.ATTACHMENT_MODEL
+    WIRELESS_CHARGER = f'{PLATFORM}.{A300WirelessCharger.TYPE}'
 
     TYPES = {
         TOP_PLATE: A300TopPlate,

--- a/clearpath_config/platform/attachments/config.py
+++ b/clearpath_config/platform/attachments/config.py
@@ -54,10 +54,10 @@ class AttachmentsConfig:
 
     def __init__(
             self,
-            attachment,
+            platform_cls,
             config: dict = {}
             ) -> None:
-        self._attach_type = attachment
+        self._platform_cls = platform_cls
         self._attachments = AttachmentListConfig()
         self.config = config
 
@@ -78,7 +78,8 @@ class AttachmentsConfig:
         self._attachments.remove_all()
         # Load New
         for a in attachments:
-            if self._attach_type.is_valid(a['type']):
-                attachment = self._attach_type(a['type'])()
+            if self._platform_cls.is_valid_attachment(a['type']):
+                att_cls = self._platform_cls.get_attachment_class(a['type'])
+                attachment = att_cls()
                 attachment.from_dict(a)
                 self._attachments.add(attachment)

--- a/clearpath_config/platform/attachments/dd100.py
+++ b/clearpath_config/platform/attachments/dd100.py
@@ -33,8 +33,7 @@ from clearpath_config.platform.types.attachment import BaseAttachment, PlatformA
 
 
 class DD100TopPlate(BaseAttachment):
-    PLATFORM = 'dd100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
+    TYPE = 'top_plate'
     PACS = 'pacs'
     MODELS = [PACS]
     PARENT = 'default_mount'
@@ -42,7 +41,7 @@ class DD100TopPlate(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = PACS,
             enabled: bool = BaseAttachment.ENABLED,
             height: float = HEIGHT,
@@ -68,7 +67,7 @@ class DD100TopPlate(BaseAttachment):
 class DD100Attachment(PlatformAttachment):
     PLATFORM = 'dd100'
     # Top Plates
-    TOP_PLATE = DD100TopPlate.ATTACHMENT_MODEL
+    TOP_PLATE = f'{PLATFORM}.{DD100TopPlate.TYPE}'
 
     TYPES = {
         TOP_PLATE: DD100TopPlate,

--- a/clearpath_config/platform/attachments/dd150.py
+++ b/clearpath_config/platform/attachments/dd150.py
@@ -34,12 +34,11 @@ from clearpath_config.platform.types.attachment import BaseAttachment, PlatformA
 
 
 class DD150TopPlate(DD100TopPlate):
-    PLATFORM = 'dd150'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
+    TYPE = 'top_plate'
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DD100TopPlate.PACS,
             enabled: bool = BaseAttachment.ENABLED,
             height: float = DD100TopPlate.HEIGHT,
@@ -54,7 +53,7 @@ class DD150TopPlate(DD100TopPlate):
 class DD150Attachment(PlatformAttachment):
     PLATFORM = 'dd150'
     # Top Plates
-    TOP_PLATE = DD150TopPlate.ATTACHMENT_MODEL
+    TOP_PLATE = f'{PLATFORM}.{DD150TopPlate.TYPE}'
 
     TYPES = {
         TOP_PLATE: DD150TopPlate,

--- a/clearpath_config/platform/attachments/dd150.py
+++ b/clearpath_config/platform/attachments/dd150.py
@@ -28,13 +28,13 @@
 from typing import List
 
 from clearpath_config.common.types.accessory import Accessory
-from clearpath_config.common.types.platform import Platform
+
 from clearpath_config.platform.attachments.dd100 import DD100TopPlate
 from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
 
 
 class DD150TopPlate(DD100TopPlate):
-    PLATFORM = Platform.DD150
+    PLATFORM = 'dd150'
     ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
 
     def __init__(
@@ -52,7 +52,7 @@ class DD150TopPlate(DD100TopPlate):
 
 # DD150 Attachments
 class DD150Attachment(PlatformAttachment):
-    PLATFORM = Platform.DD150
+    PLATFORM = 'dd150'
     # Top Plates
     TOP_PLATE = DD150TopPlate.ATTACHMENT_MODEL
 

--- a/clearpath_config/platform/attachments/do100.py
+++ b/clearpath_config/platform/attachments/do100.py
@@ -34,12 +34,11 @@ from clearpath_config.platform.types.attachment import BaseAttachment, PlatformA
 
 
 class DO100TopPlate(DD100TopPlate):
-    PLATFORM = 'do100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
+    TYPE = 'top_plate'
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DD100TopPlate.PACS,
             enabled: bool = BaseAttachment.ENABLED,
             height: float = DD100TopPlate.HEIGHT,
@@ -54,7 +53,7 @@ class DO100TopPlate(DD100TopPlate):
 class DO100Attachment(PlatformAttachment):
     PLATFORM = 'do100'
     # Top Plates
-    TOP_PLATE = DO100TopPlate.ATTACHMENT_MODEL
+    TOP_PLATE = f'{PLATFORM}.{DO100TopPlate.TYPE}'
 
     TYPES = {
         TOP_PLATE: DO100TopPlate,

--- a/clearpath_config/platform/attachments/do100.py
+++ b/clearpath_config/platform/attachments/do100.py
@@ -28,13 +28,13 @@
 from typing import List
 
 from clearpath_config.common.types.accessory import Accessory
-from clearpath_config.common.types.platform import Platform
+
 from clearpath_config.platform.attachments.dd100 import DD100TopPlate
 from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
 
 
 class DO100TopPlate(DD100TopPlate):
-    PLATFORM = Platform.DO100
+    PLATFORM = 'do100'
     ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
 
     def __init__(
@@ -52,7 +52,7 @@ class DO100TopPlate(DD100TopPlate):
 
 # DO100 Attachments
 class DO100Attachment(PlatformAttachment):
-    PLATFORM = Platform.DO100
+    PLATFORM = 'do100'
     # Top Plates
     TOP_PLATE = DO100TopPlate.ATTACHMENT_MODEL
 

--- a/clearpath_config/platform/attachments/do150.py
+++ b/clearpath_config/platform/attachments/do150.py
@@ -34,12 +34,11 @@ from clearpath_config.platform.types.attachment import BaseAttachment, PlatformA
 
 
 class DO150TopPlate(DD100TopPlate):
-    PLATFORM = 'do150'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
+    TYPE = 'top_plate'
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DD100TopPlate.PACS,
             enabled: bool = BaseAttachment.ENABLED,
             height: float = DD100TopPlate.HEIGHT,
@@ -54,7 +53,7 @@ class DO150TopPlate(DD100TopPlate):
 class DO150Attachment(PlatformAttachment):
     PLATFORM = 'do100'
     # Top Plates
-    TOP_PLATE = DO150TopPlate.ATTACHMENT_MODEL
+    TOP_PLATE = f'{PLATFORM}.{DO150TopPlate.TYPE}'
 
     TYPES = {
         TOP_PLATE: DO150TopPlate,

--- a/clearpath_config/platform/attachments/do150.py
+++ b/clearpath_config/platform/attachments/do150.py
@@ -28,13 +28,13 @@
 from typing import List
 
 from clearpath_config.common.types.accessory import Accessory
-from clearpath_config.common.types.platform import Platform
+
 from clearpath_config.platform.attachments.dd100 import DD100TopPlate
 from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
 
 
 class DO150TopPlate(DD100TopPlate):
-    PLATFORM = Platform.DO150
+    PLATFORM = 'do150'
     ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
 
     def __init__(
@@ -52,7 +52,7 @@ class DO150TopPlate(DD100TopPlate):
 
 # DO150 Attachments
 class DO150Attachment(PlatformAttachment):
-    PLATFORM = Platform.DO100
+    PLATFORM = 'do100'
     # Top Plates
     TOP_PLATE = DO150TopPlate.ATTACHMENT_MODEL
 

--- a/clearpath_config/platform/attachments/generic.py
+++ b/clearpath_config/platform/attachments/generic.py
@@ -25,10 +25,10 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from clearpath_config.common.types.platform import Platform
+
 from clearpath_config.platform.types.attachment import PlatformAttachment
 
 
 # Generic Attachments
 class GENERICAttachment(PlatformAttachment):
-    PLATFORM = Platform.GENERIC
+    PLATFORM = 'generic'

--- a/clearpath_config/platform/attachments/j100.py
+++ b/clearpath_config/platform/attachments/j100.py
@@ -34,8 +34,7 @@ from clearpath_config.platform.types.attachment import BaseAttachment, PlatformA
 
 
 class J100Fender(BaseAttachment):
-    PLATFORM = 'j100'
-    ATTACHMENT_MODEL = '%s.fender' % PLATFORM
+    TYPE = 'fender'
     DEFAULT = 'default'
     SENSOR = 'sensor'
     MODELS = [DEFAULT, SENSOR]
@@ -43,7 +42,7 @@ class J100Fender(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = PARENT,
@@ -54,8 +53,7 @@ class J100Fender(BaseAttachment):
 
 
 class J100TopPlate(BaseAttachment):
-    PLATFORM = 'j100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
+    TYPE = 'top_plate'
     ARK_ENCLOSURE = 'ark_enclosure'
     DEFAULT = ARK_ENCLOSURE
     MODELS = [DEFAULT]
@@ -63,7 +61,7 @@ class J100TopPlate(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = Accessory.PARENT,
@@ -76,8 +74,8 @@ class J100TopPlate(BaseAttachment):
 # J100 Jackal Attachments
 class J100Attachment(PlatformAttachment):
     PLATFORM = 'j100'
-    TOP_PLATE = J100TopPlate.ATTACHMENT_MODEL
-    FENDER = J100Fender.ATTACHMENT_MODEL
+    TOP_PLATE = f'{PLATFORM}.{J100TopPlate.TYPE}'
+    FENDER = f'{PLATFORM}.{J100Fender.TYPE}'
     TYPES = {
         TOP_PLATE: J100TopPlate,
         FENDER: J100Fender,

--- a/clearpath_config/platform/attachments/j100.py
+++ b/clearpath_config/platform/attachments/j100.py
@@ -29,12 +29,12 @@
 from typing import List
 
 from clearpath_config.common.types.accessory import Accessory
-from clearpath_config.common.types.platform import Platform
+
 from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
 
 
 class J100Fender(BaseAttachment):
-    PLATFORM = Platform.J100
+    PLATFORM = 'j100'
     ATTACHMENT_MODEL = '%s.fender' % PLATFORM
     DEFAULT = 'default'
     SENSOR = 'sensor'
@@ -54,7 +54,7 @@ class J100Fender(BaseAttachment):
 
 
 class J100TopPlate(BaseAttachment):
-    PLATFORM = Platform.J100
+    PLATFORM = 'j100'
     ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
     ARK_ENCLOSURE = 'ark_enclosure'
     DEFAULT = ARK_ENCLOSURE
@@ -75,7 +75,7 @@ class J100TopPlate(BaseAttachment):
 
 # J100 Jackal Attachments
 class J100Attachment(PlatformAttachment):
-    PLATFORM = Platform.J100
+    PLATFORM = 'j100'
     TOP_PLATE = J100TopPlate.ATTACHMENT_MODEL
     FENDER = J100Fender.ATTACHMENT_MODEL
     TYPES = {

--- a/clearpath_config/platform/attachments/mux.py
+++ b/clearpath_config/platform/attachments/mux.py
@@ -27,39 +27,34 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from clearpath_config.common.types.platform import Platform
 from clearpath_config.platform.attachments.config import AttachmentsConfig
-from clearpath_config.platform.types.attachment import BaseAttachment
 
 
 class AttachmentsConfigMux:
 
     def __new__(cls, platform: str, attachments: dict = None) -> AttachmentsConfig:
-        # Look up the platform's attachment class from the registry
         platform_cls = Platform.get(platform)
-        attachment_cls = platform_cls.ATTACHMENT_CLASS
-        if attachment_cls is None:
-            return AttachmentsConfig(BaseAttachment)
-        if not attachments:
-            return AttachmentsConfig(attachment_cls)
-        # Pre-Process Entries
+
+        # If attachments is left as empty list, do not load default attachments
+        if attachments is None:
+            # Use default attachments defined by the platform
+            attachments = [dict(a) for a in platform_cls.DEFAULT_ATTACHMENTS]
+
         attachments = AttachmentsConfigMux.preprocess(platform, attachments)
-        # Add All Attachments from all registered platforms
-        attachments_config = AttachmentsConfig(BaseAttachment)
-        for name in Platform.all_names():
-            pcls = Platform.get(name)
-            if pcls.ATTACHMENT_CLASS is not None:
-                ac = AttachmentsConfig(pcls.ATTACHMENT_CLASS)
-                ac.config = attachments
-                attachments_config += ac
-        return attachments_config
+
+        config = AttachmentsConfig(platform_cls)
+        config.config = attachments
+        return config
 
     @staticmethod
-    def preprocess(platform: str, attachments: dict):
-        for i, a in enumerate(attachments):
+    def preprocess(platform: str, attachments: list):
+        result = []
+        for a in attachments:
+            a = dict(a)
             if 'name' not in a:
                 raise ValueError(f'Attachment {a} is missing parameter "name"')
             if 'type' not in a:
                 raise ValueError(f'Attachment {a} is missing parameter "type"')
             if '.' not in a['type']:
                 a['type'] = f'{platform}.{a["type"]}'
-            attachments[i] = a
-        return attachments
+            result.append(a)
+        return result

--- a/clearpath_config/platform/attachments/mux.py
+++ b/clearpath_config/platform/attachments/mux.py
@@ -26,47 +26,30 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 from clearpath_config.common.types.platform import Platform
-from clearpath_config.platform.attachments.a200 import A200Attachment
-from clearpath_config.platform.attachments.a300 import A300Attachment
 from clearpath_config.platform.attachments.config import AttachmentsConfig
-from clearpath_config.platform.attachments.dd100 import DD100Attachment
-from clearpath_config.platform.attachments.dd150 import DD150Attachment
-from clearpath_config.platform.attachments.do100 import DO100Attachment
-from clearpath_config.platform.attachments.do150 import DO150Attachment
-from clearpath_config.platform.attachments.generic import GENERICAttachment
-from clearpath_config.platform.attachments.j100 import J100Attachment
-from clearpath_config.platform.attachments.r100 import R100Attachment
-from clearpath_config.platform.attachments.w200 import W200Attachment
 from clearpath_config.platform.types.attachment import BaseAttachment
 
 
 class AttachmentsConfigMux:
-    PLATFORM = {
-        Platform.A200: AttachmentsConfig(A200Attachment),
-        Platform.A300: AttachmentsConfig(A300Attachment),
-        Platform.DD100: AttachmentsConfig(DD100Attachment),
-        Platform.DO100: AttachmentsConfig(DO100Attachment),
-        Platform.DD150: AttachmentsConfig(DD150Attachment),
-        Platform.DO150: AttachmentsConfig(DO150Attachment),
-        Platform.GENERIC: AttachmentsConfig(GENERICAttachment),
-        Platform.J100: AttachmentsConfig(J100Attachment),
-        Platform.W200: AttachmentsConfig(W200Attachment),
-        Platform.R100: AttachmentsConfig(R100Attachment),
-    }
 
     def __new__(cls, platform: str, attachments: dict = None) -> AttachmentsConfig:
-        # Check Platform is Supported
-        if platform not in cls.PLATFORM:
-            raise ValueError(f'Platform "{platform}" must be one of "{cls.PLATFORM.keys()}"')
+        # Look up the platform's attachment class from the registry
+        platform_cls = Platform.get(platform)
+        attachment_cls = platform_cls.ATTACHMENT_CLASS
+        if attachment_cls is None:
+            return AttachmentsConfig(BaseAttachment)
         if not attachments:
-            return cls.PLATFORM[platform]
+            return AttachmentsConfig(attachment_cls)
         # Pre-Process Entries
         attachments = AttachmentsConfigMux.preprocess(platform, attachments)
-        # Add All Attachments
+        # Add All Attachments from all registered platforms
         attachments_config = AttachmentsConfig(BaseAttachment)
-        for p in cls.PLATFORM:
-            cls.PLATFORM[p].config = attachments
-            attachments_config += cls.PLATFORM[p]
+        for name in Platform.all_names():
+            pcls = Platform.get(name)
+            if pcls.ATTACHMENT_CLASS is not None:
+                ac = AttachmentsConfig(pcls.ATTACHMENT_CLASS)
+                ac.config = attachments
+                attachments_config += ac
         return attachments_config
 
     @staticmethod

--- a/clearpath_config/platform/attachments/r100.py
+++ b/clearpath_config/platform/attachments/r100.py
@@ -33,8 +33,7 @@ from clearpath_config.platform.types.attachment import BaseAttachment, PlatformA
 
 
 class R100FAMS(BaseAttachment):
-    PLATFORM = 'r100'
-    ATTACHMENT_MODEL = '%s.fams' % PLATFORM
+    TYPE = 'fams'
     DEFAULT = 'default'
     MODELS = [DEFAULT]
     PARENT = 'default_mount'
@@ -42,7 +41,7 @@ class R100FAMS(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             table_height: float = TABLE_HEIGHT,
             enabled: bool = BaseAttachment.ENABLED,
@@ -66,8 +65,7 @@ class R100FAMS(BaseAttachment):
 
 
 class R100HAMS(BaseAttachment):
-    PLATFORM = 'r100'
-    ATTACHMENT_MODEL = '%s.hams' % PLATFORM
+    TYPE = 'hams'
     DEFAULT = 'default'
     MODELS = [DEFAULT]
     PARENT = 'default_mount'
@@ -76,7 +74,7 @@ class R100HAMS(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             table_height: float = TABLE_HEIGHT,
             mount_height: float = MOUNT_HEIGHT,
@@ -105,8 +103,7 @@ class R100HAMS(BaseAttachment):
 
 
 class R100Tower(BaseAttachment):
-    PLATFORM = 'r100'
-    ATTACHMENT_MODEL = '%s.tower' % PLATFORM
+    TYPE = 'tower'
     DEFAULT = 'default'
     MODELS = [DEFAULT]
     PARENT = 'default_mount'
@@ -115,7 +112,7 @@ class R100Tower(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = PARENT,
@@ -145,9 +142,9 @@ class R100Tower(BaseAttachment):
 class R100Attachment(PlatformAttachment):
     PLATFORM = 'r100'
     # Arm Mount
-    HAMS = R100HAMS.ATTACHMENT_MODEL
-    FAMS = R100FAMS.ATTACHMENT_MODEL
-    TOWER = R100Tower.ATTACHMENT_MODEL
+    HAMS = f'{PLATFORM}.{R100HAMS.TYPE}'
+    FAMS = f'{PLATFORM}.{R100FAMS.TYPE}'
+    TOWER = f'{PLATFORM}.{R100Tower.TYPE}'
 
     TYPES = {
         HAMS: R100HAMS,

--- a/clearpath_config/platform/attachments/r100.py
+++ b/clearpath_config/platform/attachments/r100.py
@@ -28,12 +28,12 @@
 from typing import List
 
 from clearpath_config.common.types.accessory import Accessory
-from clearpath_config.common.types.platform import Platform
+
 from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
 
 
 class R100FAMS(BaseAttachment):
-    PLATFORM = Platform.R100
+    PLATFORM = 'r100'
     ATTACHMENT_MODEL = '%s.fams' % PLATFORM
     DEFAULT = 'default'
     MODELS = [DEFAULT]
@@ -66,7 +66,7 @@ class R100FAMS(BaseAttachment):
 
 
 class R100HAMS(BaseAttachment):
-    PLATFORM = Platform.R100
+    PLATFORM = 'r100'
     ATTACHMENT_MODEL = '%s.hams' % PLATFORM
     DEFAULT = 'default'
     MODELS = [DEFAULT]
@@ -105,7 +105,7 @@ class R100HAMS(BaseAttachment):
 
 
 class R100Tower(BaseAttachment):
-    PLATFORM = Platform.R100
+    PLATFORM = 'r100'
     ATTACHMENT_MODEL = '%s.tower' % PLATFORM
     DEFAULT = 'default'
     MODELS = [DEFAULT]
@@ -143,7 +143,7 @@ class R100Tower(BaseAttachment):
 
 # R100 Attachments
 class R100Attachment(PlatformAttachment):
-    PLATFORM = Platform.R100
+    PLATFORM = 'r100'
     # Arm Mount
     HAMS = R100HAMS.ATTACHMENT_MODEL
     FAMS = R100FAMS.ATTACHMENT_MODEL

--- a/clearpath_config/platform/attachments/w200.py
+++ b/clearpath_config/platform/attachments/w200.py
@@ -27,12 +27,12 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from typing import List
 
-from clearpath_config.common.types.platform import Platform
+
 from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
 
 
 class W200Generator(BaseAttachment):
-    PLATFORM = Platform.W200
+    PLATFORM = 'w200'
     ATTACHMENT_MODEL = '%s.generator' % PLATFORM
     DEFAULT = 'default'
     MODELS = [DEFAULT]
@@ -53,7 +53,7 @@ class W200Generator(BaseAttachment):
 
 
 class W200Bulkhead(BaseAttachment):
-    PLATFORM = Platform.W200
+    PLATFORM = 'w200'
     ATTACHMENT_MODEL = '%s.bulkhead' % PLATFORM
     DEFAULT = 'default'
     ARM_PLATE = 'arm_plate'
@@ -75,7 +75,7 @@ class W200Bulkhead(BaseAttachment):
 
 
 class W200ArmPlate(BaseAttachment):
-    PLATFORM = Platform.W200
+    PLATFORM = 'w200'
     ATTACHMENT_MODEL = '%s.arm_plate' % PLATFORM
     DEFAULT = 'default'
     MODELS = [DEFAULT]
@@ -97,7 +97,7 @@ class W200ArmPlate(BaseAttachment):
 
 # W200 Attachments
 class W200Attachment(PlatformAttachment):
-    PLATFORM = Platform.W200
+    PLATFORM = 'w200'
     # Generator
     GENERATOR = W200Generator.ATTACHMENT_MODEL
     # Bulkhead

--- a/clearpath_config/platform/attachments/w200.py
+++ b/clearpath_config/platform/attachments/w200.py
@@ -32,8 +32,7 @@ from clearpath_config.platform.types.attachment import BaseAttachment, PlatformA
 
 
 class W200Generator(BaseAttachment):
-    PLATFORM = 'w200'
-    ATTACHMENT_MODEL = '%s.generator' % PLATFORM
+    TYPE = 'generator'
     DEFAULT = 'default'
     MODELS = [DEFAULT]
     PARENT = 'default_mount'
@@ -42,7 +41,7 @@ class W200Generator(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = PARENT,
@@ -53,8 +52,7 @@ class W200Generator(BaseAttachment):
 
 
 class W200Bulkhead(BaseAttachment):
-    PLATFORM = 'w200'
-    ATTACHMENT_MODEL = '%s.bulkhead' % PLATFORM
+    TYPE = 'bulkhead'
     DEFAULT = 'default'
     ARM_PLATE = 'arm_plate'
     MODELS = [DEFAULT, ARM_PLATE]
@@ -64,7 +62,7 @@ class W200Bulkhead(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = PARENT,
@@ -75,8 +73,7 @@ class W200Bulkhead(BaseAttachment):
 
 
 class W200ArmPlate(BaseAttachment):
-    PLATFORM = 'w200'
-    ATTACHMENT_MODEL = '%s.arm_plate' % PLATFORM
+    TYPE = 'arm_plate'
     DEFAULT = 'default'
     MODELS = [DEFAULT]
     PARENT = 'default_mount'
@@ -85,7 +82,7 @@ class W200ArmPlate(BaseAttachment):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = BaseAttachment.ENABLED,
             parent: str = PARENT,
@@ -99,11 +96,11 @@ class W200ArmPlate(BaseAttachment):
 class W200Attachment(PlatformAttachment):
     PLATFORM = 'w200'
     # Generator
-    GENERATOR = W200Generator.ATTACHMENT_MODEL
+    GENERATOR = f'{PLATFORM}.{W200Generator.TYPE}'
     # Bulkhead
-    BULKHEAD = W200Bulkhead.ATTACHMENT_MODEL
+    BULKHEAD = f'{PLATFORM}.{W200Bulkhead.TYPE}'
     # ArmPlate
-    ARM_PLATE = W200ArmPlate.ATTACHMENT_MODEL
+    ARM_PLATE = f'{PLATFORM}.{W200ArmPlate.TYPE}'
 
     TYPES = {
         GENERATOR: W200Generator,

--- a/clearpath_config/platform/battery.py
+++ b/clearpath_config/platform/battery.py
@@ -71,50 +71,13 @@ class BatteryConfig(BaseConfig):
     S4P1 = 'S4P1'
     S4P3 = 'S4P3'
 
-    VALID = {
-        Platform.GENERIC: {
-            UNKNOWN: [UNKNOWN]
-        },
-        Platform.A200: {
-            ES20_12C: [S2P1],
-            HE2613: [S1P3, S1P4],
-            HE2411: [S1P3, S1P4],
-            HE2410: [S1P3, S1P4],
-        },
-        Platform.A300: {
-            S_24V20_U1: [S1P2, S1P4, S1P6],
-        },
-        Platform.DD100: {
-            TLV1222: [S1P1],
-            PH3054: [S1P1],
-        },
-        Platform.DO100: {
-            TLV1222: [S1P1, S1P2, S1P3],
-            PH3054: [S1P1, S1P2, S1P3],
-        },
-        Platform.DD150: {
-            TLV1222: [S1P1],
-            RB20: [S1P1],
-        },
-        Platform.DO150: {
-            TLV1222: [S1P1, S1P2, S1P3],
-            RB20: [S1P1, S1P2, S1P3],
-        },
-        Platform.J100: {
-            HE2613: [S1P1],
-            HE2411: [S1P1],
-            HE2410: [S1P1],
-        },
-        Platform.R100: {
-            DTM8A31: [S1P2],
-        },
-        Platform.W200: {
-            U1_35: [S4P3],
-            NEC_ALM12V35: [S4P3],
-            VALENCE_U24_12XP: [S4P1],
-            VALENCE_U27_12XP: [S4P1],
-        },
-    }
+    VALID = {}  # Populated dynamically from platform registry
+
+    @staticmethod
+    def _get_valid_batteries(platform=None):
+        if platform is None:
+            platform = BaseConfig.get_platform_model()
+        return Platform.get(platform).VALID_BATTERIES
 
     TEMPLATE = {
         BATTERY: {
@@ -166,9 +129,10 @@ class BatteryConfig(BaseConfig):
 
     def update_defaults(self) -> None:
         platform = BaseConfig.get_platform_model()
-        self.DEFAULTS[self.MODEL] = list(self.VALID[platform])[0]
+        valid = self._get_valid_batteries(platform)
+        self.DEFAULTS[self.MODEL] = list(valid)[0]
         self.DEFAULTS[self.CONFIGURATION] = list(
-            self.VALID[platform][self.DEFAULTS[self.MODEL]])[0]
+            valid[self.DEFAULTS[self.MODEL]])[0]
 
     def update(self, serial_number: bool = False) -> None:
         if serial_number:
@@ -187,13 +151,10 @@ class BatteryConfig(BaseConfig):
     @model.setter
     def model(self, value: str) -> None:
         platform = BaseConfig.get_platform_model()
-        if platform not in self.VALID:
+        valid = self._get_valid_batteries(platform)
+        if value not in valid:
             raise ValueError(
-                f'Platform "{platform}" is invalid. Must be one of "{list(self.VALID)}"'
-            )
-        if value not in self.VALID[platform]:
-            raise ValueError(
-                f'Battery model "{value}" is invalid. Battery model for platform "{platform}" must be one of "{list(self.VALID[platform])}"'  # noqa:E501
+                f'Battery model "{value}" is invalid. Battery model for platform "{platform}" must be one of "{list(valid)}"'  # noqa:E501
             )
         self._model = value
 
@@ -208,17 +169,14 @@ class BatteryConfig(BaseConfig):
     @configuration.setter
     def configuration(self, value: str) -> None:
         platform = BaseConfig.get_platform_model()
-        if platform not in self.VALID:
+        valid = self._get_valid_batteries(platform)
+        if self.model not in valid:
             raise ValueError(
-                f'Platform {platform} is invalid. Must be one of: {list(self.VALID)}'
+                f'Battery model "{self.model}" is invalid. Battery model for platform "{platform}" it must be one of "{list(valid)}"'  # noqa:E501
             )
-        if self.model not in self.VALID[platform]:
+        if value not in valid[self.model]:
             raise ValueError(
-                f'Battery model "{self.model}" is invalid. Battery model for platform "{platform}" it must be one of "{list(self.VALID[platform])}"'  # noqa:E501
-            )
-        if value not in self.VALID[platform][self.model]:
-            raise ValueError(
-                f'Battery configuration "{value}" is invalid. For platform "{platform}" and battery model "{self.model}" it must be one of "{list(self.VALID[platform][self.model])}"'  # noqa:E501
+                f'Battery configuration "{value}" is invalid. For platform "{platform}" and battery model "{self.model}" it must be one of "{list(valid[self.model])}"'  # noqa:E501
             )
         self._configuration = value
 

--- a/clearpath_config/platform/can.py
+++ b/clearpath_config/platform/can.py
@@ -194,18 +194,7 @@ class CANAdapterConfig:
         VirtualCANAdapter.SERIAL_DEV: '/dev/ttycan1',
         VirtualCANAdapter.PORT: 11413
     }
-    DEFAULTS = {
-        Platform.A200: [],
-        Platform.A300: [VCAN0_DEFAULT, VCAN1_DEFAULT],
-        Platform.DD100: [VCAN0_DEFAULT],
-        Platform.DD150: [VCAN0_DEFAULT],
-        Platform.DO100: [VCAN0_DEFAULT],
-        Platform.DO150: [VCAN0_DEFAULT],
-        Platform.GENERIC: [],
-        Platform.J100: [],
-        Platform.R100: [VCAN0_DEFAULT],
-        Platform.W200: [],
-    }
+    DEFAULTS = {}  # Populated dynamically from platform registry
 
     def __init__(
             self,
@@ -236,7 +225,8 @@ class CANAdapterConfig:
 
     def update(self, serial_number: bool = False) -> None:
         if serial_number:
-            self.config = self.DEFAULTS[BaseConfig.get_platform_model()]
+            platform = BaseConfig.get_platform_model()
+            self.config = Platform.get(platform).DEFAULT_CAN_ADAPTERS
 
 
 class CANBridge:
@@ -397,18 +387,7 @@ class CANBridgeConfig:
         # }
     ]
 
-    DEFAULTS = {
-        Platform.A200: [],
-        Platform.A300: A300_DEFAULT,
-        Platform.DD100: SINGLE_VCAN_DEFAULT,
-        Platform.DD150: SINGLE_VCAN_DEFAULT,
-        Platform.DO100: SINGLE_VCAN_DEFAULT,
-        Platform.DO150: SINGLE_VCAN_DEFAULT,
-        Platform.GENERIC: [],
-        Platform.J100: [],
-        Platform.R100: SINGLE_VCAN_DEFAULT,
-        Platform.W200: [],
-    }
+    DEFAULTS = {}  # Populated dynamically from platform registry
 
     def __init__(
             self,
@@ -437,4 +416,5 @@ class CANBridgeConfig:
 
     def update(self, serial_number: bool = False) -> None:
         if serial_number:
-            self.config = self.DEFAULTS[BaseConfig.get_platform_model()]
+            platform = BaseConfig.get_platform_model()
+            self.config = Platform.get(platform).DEFAULT_CAN_BRIDGES

--- a/clearpath_config/platform/definitions/__init__.py
+++ b/clearpath_config/platform/definitions/__init__.py
@@ -25,51 +25,15 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from typing import List
 
-from clearpath_config.common.types.accessory import Accessory
-
-from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
-
-
-class DD100TopPlate(BaseAttachment):
-    PLATFORM = 'dd100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
-    PACS = 'pacs'
-    MODELS = [PACS]
-    PARENT = 'default_mount'
-    HEIGHT = 0.1
-
-    def __init__(
-            self,
-            name: str = ATTACHMENT_MODEL,
-            model: str = PACS,
-            enabled: bool = BaseAttachment.ENABLED,
-            height: float = HEIGHT,
-            parent: str = PARENT,
-            xyz: List[float] = Accessory.XYZ,
-            rpy: List[float] = Accessory.RPY
-            ) -> None:
-        super().__init__(name, model, enabled, parent, xyz, rpy)
-        self.height = height
-
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d['height'] = self.height
-        return d
-
-    def from_dict(self, d: dict) -> None:
-        super().from_dict(d)
-        if 'height' in d:
-            self.height = d['height']
-
-
-# DD100 Attachments
-class DD100Attachment(PlatformAttachment):
-    PLATFORM = 'dd100'
-    # Top Plates
-    TOP_PLATE = DD100TopPlate.ATTACHMENT_MODEL
-
-    TYPES = {
-        TOP_PLATE: DD100TopPlate,
-    }
+# Import all concrete platform definitions so they auto-register
+from clearpath_config.platform.definitions.a200 import A200PlatformConfig  # noqa: F401
+from clearpath_config.platform.definitions.a300 import A300PlatformConfig  # noqa: F401
+from clearpath_config.platform.definitions.dd100 import DD100PlatformConfig  # noqa: F401
+from clearpath_config.platform.definitions.dd150 import DD150PlatformConfig  # noqa: F401
+from clearpath_config.platform.definitions.do100 import DO100PlatformConfig  # noqa: F401
+from clearpath_config.platform.definitions.do150 import DO150PlatformConfig  # noqa: F401
+from clearpath_config.platform.definitions.generic import GenericPlatformConfig  # noqa: F401
+from clearpath_config.platform.definitions.j100 import J100PlatformConfig  # noqa: F401
+from clearpath_config.platform.definitions.r100 import R100PlatformConfig  # noqa: F401
+from clearpath_config.platform.definitions.w200 import W200PlatformConfig  # noqa: F401

--- a/clearpath_config/platform/definitions/a200.py
+++ b/clearpath_config/platform/definitions/a200.py
@@ -30,7 +30,12 @@ from clearpath_config.common.types.platform import (
     PACSProfile,
     Platform,
 )
-from clearpath_config.platform.attachments.a200 import A200Attachment
+from clearpath_config.platform.attachments.a200 import (
+    A200Bumper,
+    A200ObserverBackpack,
+    A200SensorArch,
+    A200TopPlate,
+)
 from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
@@ -55,7 +60,15 @@ class A200PlatformConfig(BasePlatformConfig):
     }
     DEFAULT_CAN_ADAPTERS = []
     DEFAULT_CAN_BRIDGES = []
-    ATTACHMENT_CLASS = A200Attachment
+    DEFAULT_ATTACHMENTS = [
+        {'name': 'front_bumper', 'type': 'a200.bumper', 'parent': 'front_bumper_mount'},
+        {'name': 'rear_bumper', 'type': 'a200.bumper', 'parent': 'rear_bumper_mount'},
+        {'name': 'top_plate', 'type': 'a200.top_plate'},
+    ]
 
 
 Platform.register(A200PlatformConfig)
+A200PlatformConfig.register_attachment(A200TopPlate)
+A200PlatformConfig.register_attachment(A200Bumper)
+A200PlatformConfig.register_attachment(A200SensorArch)
+A200PlatformConfig.register_attachment(A200ObserverBackpack)

--- a/clearpath_config/platform/definitions/a200.py
+++ b/clearpath_config/platform/definitions/a200.py
@@ -25,51 +25,35 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from typing import List
-
-from clearpath_config.common.types.accessory import Accessory
-
-from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
-
-
-class DD100TopPlate(BaseAttachment):
-    PLATFORM = 'dd100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
-    PACS = 'pacs'
-    MODELS = [PACS]
-    PARENT = 'default_mount'
-    HEIGHT = 0.1
-
-    def __init__(
-            self,
-            name: str = ATTACHMENT_MODEL,
-            model: str = PACS,
-            enabled: bool = BaseAttachment.ENABLED,
-            height: float = HEIGHT,
-            parent: str = PARENT,
-            xyz: List[float] = Accessory.XYZ,
-            rpy: List[float] = Accessory.RPY
-            ) -> None:
-        super().__init__(name, model, enabled, parent, xyz, rpy)
-        self.height = height
-
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d['height'] = self.height
-        return d
-
-    def from_dict(self, d: dict) -> None:
-        super().from_dict(d)
-        if 'height' in d:
-            self.height = d['height']
+from clearpath_config.common.types.platform import (
+    IndexingProfile,
+    PACSProfile,
+    Platform,
+)
+from clearpath_config.platform.attachments.a200 import A200Attachment
+from clearpath_config.platform.platform import BasePlatformConfig
 
 
-# DD100 Attachments
-class DD100Attachment(PlatformAttachment):
-    PLATFORM = 'dd100'
-    # Top Plates
-    TOP_PLATE = DD100TopPlate.ATTACHMENT_MODEL
-
-    TYPES = {
-        TOP_PLATE: DD100TopPlate,
+class A200PlatformConfig(BasePlatformConfig):
+    NAME = 'a200'
+    PACS = PACSProfile(rows=8, columns=7)
+    INDEXING = IndexingProfile()
+    VALID_BATTERIES = {
+        'ES20_12C': ['S2P1'],
+        'HE2613': ['S1P3', 'S1P4'],
+        'HE2411': ['S1P3', 'S1P4'],
+        'HE2410': ['S1P3', 'S1P4'],
     }
+    VALID_DRIVETRAIN = {
+        'control': ['diff_4wd'],
+        'wheels': {
+            'front': ['outdoor', 'indoor'],
+            'rear': ['outdoor', 'indoor'],
+        },
+    }
+    DEFAULT_CAN_ADAPTERS = []
+    DEFAULT_CAN_BRIDGES = []
+    ATTACHMENT_CLASS = A200Attachment
+
+
+Platform.register(A200PlatformConfig)

--- a/clearpath_config/platform/definitions/a200.py
+++ b/clearpath_config/platform/definitions/a200.py
@@ -31,6 +31,8 @@ from clearpath_config.common.types.platform import (
     Platform,
 )
 from clearpath_config.platform.attachments.a200 import A200Attachment
+from clearpath_config.platform.battery import BatteryConfig
+from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
 
 
@@ -39,16 +41,16 @@ class A200PlatformConfig(BasePlatformConfig):
     PACS = PACSProfile(rows=8, columns=7)
     INDEXING = IndexingProfile()
     VALID_BATTERIES = {
-        'ES20_12C': ['S2P1'],
-        'HE2613': ['S1P3', 'S1P4'],
-        'HE2411': ['S1P3', 'S1P4'],
-        'HE2410': ['S1P3', 'S1P4'],
+        BatteryConfig.ES20_12C: [BatteryConfig.S2P1],
+        BatteryConfig.HE2613: [BatteryConfig.S1P3, BatteryConfig.S1P4],
+        BatteryConfig.HE2411: [BatteryConfig.S1P3, BatteryConfig.S1P4],
+        BatteryConfig.HE2410: [BatteryConfig.S1P3, BatteryConfig.S1P4],
     }
     VALID_DRIVETRAIN = {
-        'control': ['diff_4wd'],
-        'wheels': {
-            'front': ['outdoor', 'indoor'],
-            'rear': ['outdoor', 'indoor'],
+        DrivetrainConfig.CONTROL: [DrivetrainConfig.DIFF_4WD],
+        DrivetrainConfig.WHEELS: {
+            DrivetrainConfig.FRONT: [DrivetrainConfig.OUTDOOR, DrivetrainConfig.INDOOR],
+            DrivetrainConfig.REAR: [DrivetrainConfig.OUTDOOR, DrivetrainConfig.INDOOR],
         },
     }
     DEFAULT_CAN_ADAPTERS = []

--- a/clearpath_config/platform/definitions/a300.py
+++ b/clearpath_config/platform/definitions/a300.py
@@ -25,51 +25,33 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from typing import List
-
-from clearpath_config.common.types.accessory import Accessory
-
-from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
-
-
-class DD100TopPlate(BaseAttachment):
-    PLATFORM = 'dd100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
-    PACS = 'pacs'
-    MODELS = [PACS]
-    PARENT = 'default_mount'
-    HEIGHT = 0.1
-
-    def __init__(
-            self,
-            name: str = ATTACHMENT_MODEL,
-            model: str = PACS,
-            enabled: bool = BaseAttachment.ENABLED,
-            height: float = HEIGHT,
-            parent: str = PARENT,
-            xyz: List[float] = Accessory.XYZ,
-            rpy: List[float] = Accessory.RPY
-            ) -> None:
-        super().__init__(name, model, enabled, parent, xyz, rpy)
-        self.height = height
-
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d['height'] = self.height
-        return d
-
-    def from_dict(self, d: dict) -> None:
-        super().from_dict(d)
-        if 'height' in d:
-            self.height = d['height']
+from clearpath_config.common.types.platform import (
+    IndexingProfile,
+    PACSProfile,
+    Platform,
+)
+from clearpath_config.platform.attachments.a300 import A300Attachment
+from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
+from clearpath_config.platform.platform import BasePlatformConfig
 
 
-# DD100 Attachments
-class DD100Attachment(PlatformAttachment):
-    PLATFORM = 'dd100'
-    # Top Plates
-    TOP_PLATE = DD100TopPlate.ATTACHMENT_MODEL
-
-    TYPES = {
-        TOP_PLATE: DD100TopPlate,
+class A300PlatformConfig(BasePlatformConfig):
+    NAME = 'a300'
+    PACS = PACSProfile(rows=9, columns=5)
+    INDEXING = IndexingProfile()
+    VALID_BATTERIES = {
+        'S_24V20_U1': ['S1P2', 'S1P4', 'S1P6'],
     }
+    VALID_DRIVETRAIN = {
+        'control': ['diff_4wd', 'diff_fwd', 'diff_rwd', 'omni_4wd'],
+        'wheels': {
+            'front': ['outdoor', 'caster', 'mecanum'],
+            'rear': ['outdoor', 'caster', 'mecanum'],
+        },
+    }
+    DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT, CANAdapterConfig.VCAN1_DEFAULT]
+    DEFAULT_CAN_BRIDGES = CANBridgeConfig.A300_DEFAULT
+    ATTACHMENT_CLASS = A300Attachment
+
+
+Platform.register(A300PlatformConfig)

--- a/clearpath_config/platform/definitions/a300.py
+++ b/clearpath_config/platform/definitions/a300.py
@@ -31,7 +31,9 @@ from clearpath_config.common.types.platform import (
     Platform,
 )
 from clearpath_config.platform.attachments.a300 import A300Attachment
+from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
+from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
 
 
@@ -40,13 +42,16 @@ class A300PlatformConfig(BasePlatformConfig):
     PACS = PACSProfile(rows=9, columns=5)
     INDEXING = IndexingProfile()
     VALID_BATTERIES = {
-        'S_24V20_U1': ['S1P2', 'S1P4', 'S1P6'],
+        BatteryConfig.S_24V20_U1: [BatteryConfig.S1P2, BatteryConfig.S1P4, BatteryConfig.S1P6],
     }
     VALID_DRIVETRAIN = {
-        'control': ['diff_4wd', 'diff_fwd', 'diff_rwd', 'omni_4wd'],
-        'wheels': {
-            'front': ['outdoor', 'caster', 'mecanum'],
-            'rear': ['outdoor', 'caster', 'mecanum'],
+        DrivetrainConfig.CONTROL: [
+            DrivetrainConfig.DIFF_4WD, DrivetrainConfig.DIFF_FWD,
+            DrivetrainConfig.DIFF_RWD, DrivetrainConfig.OMNI_4WD,
+        ],
+        DrivetrainConfig.WHEELS: {
+            DrivetrainConfig.FRONT: [DrivetrainConfig.OUTDOOR, DrivetrainConfig.CASTER, DrivetrainConfig.MECANUM],
+            DrivetrainConfig.REAR: [DrivetrainConfig.OUTDOOR, DrivetrainConfig.CASTER, DrivetrainConfig.MECANUM],
         },
     }
     DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT, CANAdapterConfig.VCAN1_DEFAULT]

--- a/clearpath_config/platform/definitions/a300.py
+++ b/clearpath_config/platform/definitions/a300.py
@@ -30,7 +30,14 @@ from clearpath_config.common.types.platform import (
     PACSProfile,
     Platform,
 )
-from clearpath_config.platform.attachments.a300 import A300Attachment
+from clearpath_config.platform.attachments.a300 import (
+    A300AmpEnclosure,
+    A300AmpSensorArch,
+    A300Bumper,
+    A300Spotlight,
+    A300TopPlate,
+    A300WirelessCharger,
+)
 from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
 from clearpath_config.platform.drivetrain import DrivetrainConfig
@@ -50,13 +57,27 @@ class A300PlatformConfig(BasePlatformConfig):
             DrivetrainConfig.DIFF_RWD, DrivetrainConfig.OMNI_4WD,
         ],
         DrivetrainConfig.WHEELS: {
-            DrivetrainConfig.FRONT: [DrivetrainConfig.OUTDOOR, DrivetrainConfig.CASTER, DrivetrainConfig.MECANUM],
-            DrivetrainConfig.REAR: [DrivetrainConfig.OUTDOOR, DrivetrainConfig.CASTER, DrivetrainConfig.MECANUM],
+            DrivetrainConfig.FRONT: [DrivetrainConfig.OUTDOOR,
+                                     DrivetrainConfig.CASTER,
+                                     DrivetrainConfig.MECANUM],
+            DrivetrainConfig.REAR: [DrivetrainConfig.OUTDOOR,
+                                    DrivetrainConfig.CASTER,
+                                    DrivetrainConfig.MECANUM],
         },
     }
     DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT, CANAdapterConfig.VCAN1_DEFAULT]
     DEFAULT_CAN_BRIDGES = CANBridgeConfig.A300_DEFAULT
-    ATTACHMENT_CLASS = A300Attachment
+    DEFAULT_ATTACHMENTS = [
+        {'name': 'front_bumper', 'type': 'a300.bumper', 'parent': 'front_bumper_mount'},
+        {'name': 'rear_bumper', 'type': 'a300.bumper', 'parent': 'rear_bumper_mount'},
+        {'name': 'top_plate', 'type': 'a300.top_plate'},
+    ]
 
 
 Platform.register(A300PlatformConfig)
+A300PlatformConfig.register_attachment(A300TopPlate)
+A300PlatformConfig.register_attachment(A300Bumper)
+A300PlatformConfig.register_attachment(A300WirelessCharger)
+A300PlatformConfig.register_attachment(A300AmpEnclosure)
+A300PlatformConfig.register_attachment(A300AmpSensorArch)
+A300PlatformConfig.register_attachment(A300Spotlight)

--- a/clearpath_config/platform/definitions/dd100.py
+++ b/clearpath_config/platform/definitions/dd100.py
@@ -31,7 +31,9 @@ from clearpath_config.common.types.platform import (
     Platform,
 )
 from clearpath_config.platform.attachments.dd100 import DD100Attachment
+from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
+from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
 
 
@@ -40,14 +42,14 @@ class DD100PlatformConfig(BasePlatformConfig):
     PACS = PACSProfile(rows=100, columns=100)
     INDEXING = IndexingProfile(imu=1)
     VALID_BATTERIES = {
-        'TLV1222': ['S1P1'],
-        'PH3054': ['S1P1'],
+        BatteryConfig.TLV1222: [BatteryConfig.S1P1],
+        BatteryConfig.PH3054: [BatteryConfig.S1P1],
     }
     VALID_DRIVETRAIN = {
-        'control': ['diff_fwd'],
-        'wheels': {
-            'front': ['indoor'],
-            'rear': ['caster'],
+        DrivetrainConfig.CONTROL: [DrivetrainConfig.DIFF_FWD],
+        DrivetrainConfig.WHEELS: {
+            DrivetrainConfig.FRONT: [DrivetrainConfig.INDOOR],
+            DrivetrainConfig.REAR: [DrivetrainConfig.CASTER],
         },
     }
     DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]

--- a/clearpath_config/platform/definitions/dd100.py
+++ b/clearpath_config/platform/definitions/dd100.py
@@ -25,51 +25,34 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from typing import List
-
-from clearpath_config.common.types.accessory import Accessory
-
-from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
-
-
-class DD100TopPlate(BaseAttachment):
-    PLATFORM = 'dd100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
-    PACS = 'pacs'
-    MODELS = [PACS]
-    PARENT = 'default_mount'
-    HEIGHT = 0.1
-
-    def __init__(
-            self,
-            name: str = ATTACHMENT_MODEL,
-            model: str = PACS,
-            enabled: bool = BaseAttachment.ENABLED,
-            height: float = HEIGHT,
-            parent: str = PARENT,
-            xyz: List[float] = Accessory.XYZ,
-            rpy: List[float] = Accessory.RPY
-            ) -> None:
-        super().__init__(name, model, enabled, parent, xyz, rpy)
-        self.height = height
-
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d['height'] = self.height
-        return d
-
-    def from_dict(self, d: dict) -> None:
-        super().from_dict(d)
-        if 'height' in d:
-            self.height = d['height']
+from clearpath_config.common.types.platform import (
+    IndexingProfile,
+    PACSProfile,
+    Platform,
+)
+from clearpath_config.platform.attachments.dd100 import DD100Attachment
+from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
+from clearpath_config.platform.platform import BasePlatformConfig
 
 
-# DD100 Attachments
-class DD100Attachment(PlatformAttachment):
-    PLATFORM = 'dd100'
-    # Top Plates
-    TOP_PLATE = DD100TopPlate.ATTACHMENT_MODEL
-
-    TYPES = {
-        TOP_PLATE: DD100TopPlate,
+class DD100PlatformConfig(BasePlatformConfig):
+    NAME = 'dd100'
+    PACS = PACSProfile(rows=100, columns=100)
+    INDEXING = IndexingProfile(imu=1)
+    VALID_BATTERIES = {
+        'TLV1222': ['S1P1'],
+        'PH3054': ['S1P1'],
     }
+    VALID_DRIVETRAIN = {
+        'control': ['diff_fwd'],
+        'wheels': {
+            'front': ['indoor'],
+            'rear': ['caster'],
+        },
+    }
+    DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]
+    DEFAULT_CAN_BRIDGES = CANBridgeConfig.SINGLE_VCAN_DEFAULT
+    ATTACHMENT_CLASS = DD100Attachment
+
+
+Platform.register(DD100PlatformConfig)

--- a/clearpath_config/platform/definitions/dd100.py
+++ b/clearpath_config/platform/definitions/dd100.py
@@ -30,7 +30,7 @@ from clearpath_config.common.types.platform import (
     PACSProfile,
     Platform,
 )
-from clearpath_config.platform.attachments.dd100 import DD100Attachment
+from clearpath_config.platform.attachments.dd100 import DD100TopPlate
 from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
 from clearpath_config.platform.drivetrain import DrivetrainConfig
@@ -54,7 +54,8 @@ class DD100PlatformConfig(BasePlatformConfig):
     }
     DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]
     DEFAULT_CAN_BRIDGES = CANBridgeConfig.SINGLE_VCAN_DEFAULT
-    ATTACHMENT_CLASS = DD100Attachment
+    DEFAULT_ATTACHMENTS = []
 
 
 Platform.register(DD100PlatformConfig)
+DD100PlatformConfig.register_attachment(DD100TopPlate)

--- a/clearpath_config/platform/definitions/dd150.py
+++ b/clearpath_config/platform/definitions/dd150.py
@@ -25,51 +25,34 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from typing import List
-
-from clearpath_config.common.types.accessory import Accessory
-
-from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
-
-
-class DD100TopPlate(BaseAttachment):
-    PLATFORM = 'dd100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
-    PACS = 'pacs'
-    MODELS = [PACS]
-    PARENT = 'default_mount'
-    HEIGHT = 0.1
-
-    def __init__(
-            self,
-            name: str = ATTACHMENT_MODEL,
-            model: str = PACS,
-            enabled: bool = BaseAttachment.ENABLED,
-            height: float = HEIGHT,
-            parent: str = PARENT,
-            xyz: List[float] = Accessory.XYZ,
-            rpy: List[float] = Accessory.RPY
-            ) -> None:
-        super().__init__(name, model, enabled, parent, xyz, rpy)
-        self.height = height
-
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d['height'] = self.height
-        return d
-
-    def from_dict(self, d: dict) -> None:
-        super().from_dict(d)
-        if 'height' in d:
-            self.height = d['height']
+from clearpath_config.common.types.platform import (
+    IndexingProfile,
+    PACSProfile,
+    Platform,
+)
+from clearpath_config.platform.attachments.dd150 import DD150Attachment
+from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
+from clearpath_config.platform.platform import BasePlatformConfig
 
 
-# DD100 Attachments
-class DD100Attachment(PlatformAttachment):
-    PLATFORM = 'dd100'
-    # Top Plates
-    TOP_PLATE = DD100TopPlate.ATTACHMENT_MODEL
-
-    TYPES = {
-        TOP_PLATE: DD100TopPlate,
+class DD150PlatformConfig(BasePlatformConfig):
+    NAME = 'dd150'
+    PACS = PACSProfile(rows=100, columns=100)
+    INDEXING = IndexingProfile(imu=1)
+    VALID_BATTERIES = {
+        'TLV1222': ['S1P1'],
+        'RB20': ['S1P1'],
     }
+    VALID_DRIVETRAIN = {
+        'control': ['diff_fwd'],
+        'wheels': {
+            'front': ['indoor'],
+            'rear': ['caster'],
+        },
+    }
+    DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]
+    DEFAULT_CAN_BRIDGES = CANBridgeConfig.SINGLE_VCAN_DEFAULT
+    ATTACHMENT_CLASS = DD150Attachment
+
+
+Platform.register(DD150PlatformConfig)

--- a/clearpath_config/platform/definitions/dd150.py
+++ b/clearpath_config/platform/definitions/dd150.py
@@ -30,7 +30,7 @@ from clearpath_config.common.types.platform import (
     PACSProfile,
     Platform,
 )
-from clearpath_config.platform.attachments.dd150 import DD150Attachment
+from clearpath_config.platform.attachments.dd150 import DD150TopPlate
 from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
 from clearpath_config.platform.drivetrain import DrivetrainConfig
@@ -54,7 +54,8 @@ class DD150PlatformConfig(BasePlatformConfig):
     }
     DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]
     DEFAULT_CAN_BRIDGES = CANBridgeConfig.SINGLE_VCAN_DEFAULT
-    ATTACHMENT_CLASS = DD150Attachment
+    DEFAULT_ATTACHMENTS = []
 
 
 Platform.register(DD150PlatformConfig)
+DD150PlatformConfig.register_attachment(DD150TopPlate)

--- a/clearpath_config/platform/definitions/dd150.py
+++ b/clearpath_config/platform/definitions/dd150.py
@@ -31,7 +31,9 @@ from clearpath_config.common.types.platform import (
     Platform,
 )
 from clearpath_config.platform.attachments.dd150 import DD150Attachment
+from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
+from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
 
 
@@ -40,14 +42,14 @@ class DD150PlatformConfig(BasePlatformConfig):
     PACS = PACSProfile(rows=100, columns=100)
     INDEXING = IndexingProfile(imu=1)
     VALID_BATTERIES = {
-        'TLV1222': ['S1P1'],
-        'RB20': ['S1P1'],
+        BatteryConfig.TLV1222: [BatteryConfig.S1P1],
+        BatteryConfig.RB20: [BatteryConfig.S1P1],
     }
     VALID_DRIVETRAIN = {
-        'control': ['diff_fwd'],
-        'wheels': {
-            'front': ['indoor'],
-            'rear': ['caster'],
+        DrivetrainConfig.CONTROL: [DrivetrainConfig.DIFF_FWD],
+        DrivetrainConfig.WHEELS: {
+            DrivetrainConfig.FRONT: [DrivetrainConfig.INDOOR],
+            DrivetrainConfig.REAR: [DrivetrainConfig.CASTER],
         },
     }
     DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]

--- a/clearpath_config/platform/definitions/do100.py
+++ b/clearpath_config/platform/definitions/do100.py
@@ -25,51 +25,34 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from typing import List
-
-from clearpath_config.common.types.accessory import Accessory
-
-from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
-
-
-class DD100TopPlate(BaseAttachment):
-    PLATFORM = 'dd100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
-    PACS = 'pacs'
-    MODELS = [PACS]
-    PARENT = 'default_mount'
-    HEIGHT = 0.1
-
-    def __init__(
-            self,
-            name: str = ATTACHMENT_MODEL,
-            model: str = PACS,
-            enabled: bool = BaseAttachment.ENABLED,
-            height: float = HEIGHT,
-            parent: str = PARENT,
-            xyz: List[float] = Accessory.XYZ,
-            rpy: List[float] = Accessory.RPY
-            ) -> None:
-        super().__init__(name, model, enabled, parent, xyz, rpy)
-        self.height = height
-
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d['height'] = self.height
-        return d
-
-    def from_dict(self, d: dict) -> None:
-        super().from_dict(d)
-        if 'height' in d:
-            self.height = d['height']
+from clearpath_config.common.types.platform import (
+    IndexingProfile,
+    PACSProfile,
+    Platform,
+)
+from clearpath_config.platform.attachments.do100 import DO100Attachment
+from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
+from clearpath_config.platform.platform import BasePlatformConfig
 
 
-# DD100 Attachments
-class DD100Attachment(PlatformAttachment):
-    PLATFORM = 'dd100'
-    # Top Plates
-    TOP_PLATE = DD100TopPlate.ATTACHMENT_MODEL
-
-    TYPES = {
-        TOP_PLATE: DD100TopPlate,
+class DO100PlatformConfig(BasePlatformConfig):
+    NAME = 'do100'
+    PACS = PACSProfile(rows=100, columns=100)
+    INDEXING = IndexingProfile(imu=1)
+    VALID_BATTERIES = {
+        'TLV1222': ['S1P1', 'S1P2', 'S1P3'],
+        'PH3054': ['S1P1', 'S1P2', 'S1P3'],
     }
+    VALID_DRIVETRAIN = {
+        'control': ['omni_4wd', 'diff_4wd'],
+        'wheels': {
+            'front': ['mecanum'],
+            'rear': ['mecanum'],
+        },
+    }
+    DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]
+    DEFAULT_CAN_BRIDGES = CANBridgeConfig.SINGLE_VCAN_DEFAULT
+    ATTACHMENT_CLASS = DO100Attachment
+
+
+Platform.register(DO100PlatformConfig)

--- a/clearpath_config/platform/definitions/do100.py
+++ b/clearpath_config/platform/definitions/do100.py
@@ -31,7 +31,9 @@ from clearpath_config.common.types.platform import (
     Platform,
 )
 from clearpath_config.platform.attachments.do100 import DO100Attachment
+from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
+from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
 
 
@@ -40,14 +42,14 @@ class DO100PlatformConfig(BasePlatformConfig):
     PACS = PACSProfile(rows=100, columns=100)
     INDEXING = IndexingProfile(imu=1)
     VALID_BATTERIES = {
-        'TLV1222': ['S1P1', 'S1P2', 'S1P3'],
-        'PH3054': ['S1P1', 'S1P2', 'S1P3'],
+        BatteryConfig.TLV1222: [BatteryConfig.S1P1, BatteryConfig.S1P2, BatteryConfig.S1P3],
+        BatteryConfig.PH3054: [BatteryConfig.S1P1, BatteryConfig.S1P2, BatteryConfig.S1P3],
     }
     VALID_DRIVETRAIN = {
-        'control': ['omni_4wd', 'diff_4wd'],
-        'wheels': {
-            'front': ['mecanum'],
-            'rear': ['mecanum'],
+        DrivetrainConfig.CONTROL: [DrivetrainConfig.OMNI_4WD, DrivetrainConfig.DIFF_4WD],
+        DrivetrainConfig.WHEELS: {
+            DrivetrainConfig.FRONT: [DrivetrainConfig.MECANUM],
+            DrivetrainConfig.REAR: [DrivetrainConfig.MECANUM],
         },
     }
     DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]

--- a/clearpath_config/platform/definitions/do100.py
+++ b/clearpath_config/platform/definitions/do100.py
@@ -30,7 +30,7 @@ from clearpath_config.common.types.platform import (
     PACSProfile,
     Platform,
 )
-from clearpath_config.platform.attachments.do100 import DO100Attachment
+from clearpath_config.platform.attachments.do100 import DO100TopPlate
 from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
 from clearpath_config.platform.drivetrain import DrivetrainConfig
@@ -54,7 +54,8 @@ class DO100PlatformConfig(BasePlatformConfig):
     }
     DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]
     DEFAULT_CAN_BRIDGES = CANBridgeConfig.SINGLE_VCAN_DEFAULT
-    ATTACHMENT_CLASS = DO100Attachment
+    DEFAULT_ATTACHMENTS = []
 
 
 Platform.register(DO100PlatformConfig)
+DO100PlatformConfig.register_attachment(DO100TopPlate)

--- a/clearpath_config/platform/definitions/do150.py
+++ b/clearpath_config/platform/definitions/do150.py
@@ -25,51 +25,34 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from typing import List
-
-from clearpath_config.common.types.accessory import Accessory
-
-from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
-
-
-class DD100TopPlate(BaseAttachment):
-    PLATFORM = 'dd100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
-    PACS = 'pacs'
-    MODELS = [PACS]
-    PARENT = 'default_mount'
-    HEIGHT = 0.1
-
-    def __init__(
-            self,
-            name: str = ATTACHMENT_MODEL,
-            model: str = PACS,
-            enabled: bool = BaseAttachment.ENABLED,
-            height: float = HEIGHT,
-            parent: str = PARENT,
-            xyz: List[float] = Accessory.XYZ,
-            rpy: List[float] = Accessory.RPY
-            ) -> None:
-        super().__init__(name, model, enabled, parent, xyz, rpy)
-        self.height = height
-
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d['height'] = self.height
-        return d
-
-    def from_dict(self, d: dict) -> None:
-        super().from_dict(d)
-        if 'height' in d:
-            self.height = d['height']
+from clearpath_config.common.types.platform import (
+    IndexingProfile,
+    PACSProfile,
+    Platform,
+)
+from clearpath_config.platform.attachments.do150 import DO150Attachment
+from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
+from clearpath_config.platform.platform import BasePlatformConfig
 
 
-# DD100 Attachments
-class DD100Attachment(PlatformAttachment):
-    PLATFORM = 'dd100'
-    # Top Plates
-    TOP_PLATE = DD100TopPlate.ATTACHMENT_MODEL
-
-    TYPES = {
-        TOP_PLATE: DD100TopPlate,
+class DO150PlatformConfig(BasePlatformConfig):
+    NAME = 'do150'
+    PACS = PACSProfile(rows=100, columns=100)
+    INDEXING = IndexingProfile(imu=1)
+    VALID_BATTERIES = {
+        'TLV1222': ['S1P1', 'S1P2', 'S1P3'],
+        'RB20': ['S1P1', 'S1P2', 'S1P3'],
     }
+    VALID_DRIVETRAIN = {
+        'control': ['omni_4wd', 'diff_4wd'],
+        'wheels': {
+            'front': ['mecanum'],
+            'rear': ['mecanum'],
+        },
+    }
+    DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]
+    DEFAULT_CAN_BRIDGES = CANBridgeConfig.SINGLE_VCAN_DEFAULT
+    ATTACHMENT_CLASS = DO150Attachment
+
+
+Platform.register(DO150PlatformConfig)

--- a/clearpath_config/platform/definitions/do150.py
+++ b/clearpath_config/platform/definitions/do150.py
@@ -30,7 +30,7 @@ from clearpath_config.common.types.platform import (
     PACSProfile,
     Platform,
 )
-from clearpath_config.platform.attachments.do150 import DO150Attachment
+from clearpath_config.platform.attachments.do150 import DO150TopPlate
 from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
 from clearpath_config.platform.drivetrain import DrivetrainConfig
@@ -54,7 +54,8 @@ class DO150PlatformConfig(BasePlatformConfig):
     }
     DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]
     DEFAULT_CAN_BRIDGES = CANBridgeConfig.SINGLE_VCAN_DEFAULT
-    ATTACHMENT_CLASS = DO150Attachment
+    DEFAULT_ATTACHMENTS = []
 
 
 Platform.register(DO150PlatformConfig)
+DO150PlatformConfig.register_attachment(DO150TopPlate)

--- a/clearpath_config/platform/definitions/do150.py
+++ b/clearpath_config/platform/definitions/do150.py
@@ -31,7 +31,9 @@ from clearpath_config.common.types.platform import (
     Platform,
 )
 from clearpath_config.platform.attachments.do150 import DO150Attachment
+from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
+from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
 
 
@@ -40,14 +42,14 @@ class DO150PlatformConfig(BasePlatformConfig):
     PACS = PACSProfile(rows=100, columns=100)
     INDEXING = IndexingProfile(imu=1)
     VALID_BATTERIES = {
-        'TLV1222': ['S1P1', 'S1P2', 'S1P3'],
-        'RB20': ['S1P1', 'S1P2', 'S1P3'],
+        BatteryConfig.TLV1222: [BatteryConfig.S1P1, BatteryConfig.S1P2, BatteryConfig.S1P3],
+        BatteryConfig.RB20: [BatteryConfig.S1P1, BatteryConfig.S1P2, BatteryConfig.S1P3],
     }
     VALID_DRIVETRAIN = {
-        'control': ['omni_4wd', 'diff_4wd'],
-        'wheels': {
-            'front': ['mecanum'],
-            'rear': ['mecanum'],
+        DrivetrainConfig.CONTROL: [DrivetrainConfig.OMNI_4WD, DrivetrainConfig.DIFF_4WD],
+        DrivetrainConfig.WHEELS: {
+            DrivetrainConfig.FRONT: [DrivetrainConfig.MECANUM],
+            DrivetrainConfig.REAR: [DrivetrainConfig.MECANUM],
         },
     }
     DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]

--- a/clearpath_config/platform/definitions/generic.py
+++ b/clearpath_config/platform/definitions/generic.py
@@ -25,51 +25,32 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from typing import List
-
-from clearpath_config.common.types.accessory import Accessory
-
-from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
-
-
-class DD100TopPlate(BaseAttachment):
-    PLATFORM = 'dd100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
-    PACS = 'pacs'
-    MODELS = [PACS]
-    PARENT = 'default_mount'
-    HEIGHT = 0.1
-
-    def __init__(
-            self,
-            name: str = ATTACHMENT_MODEL,
-            model: str = PACS,
-            enabled: bool = BaseAttachment.ENABLED,
-            height: float = HEIGHT,
-            parent: str = PARENT,
-            xyz: List[float] = Accessory.XYZ,
-            rpy: List[float] = Accessory.RPY
-            ) -> None:
-        super().__init__(name, model, enabled, parent, xyz, rpy)
-        self.height = height
-
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d['height'] = self.height
-        return d
-
-    def from_dict(self, d: dict) -> None:
-        super().from_dict(d)
-        if 'height' in d:
-            self.height = d['height']
+from clearpath_config.common.types.platform import (
+    IndexingProfile,
+    PACSProfile,
+    Platform,
+)
+from clearpath_config.platform.attachments.generic import GENERICAttachment
+from clearpath_config.platform.platform import BasePlatformConfig
 
 
-# DD100 Attachments
-class DD100Attachment(PlatformAttachment):
-    PLATFORM = 'dd100'
-    # Top Plates
-    TOP_PLATE = DD100TopPlate.ATTACHMENT_MODEL
-
-    TYPES = {
-        TOP_PLATE: DD100TopPlate,
+class GenericPlatformConfig(BasePlatformConfig):
+    NAME = 'generic'
+    PACS = PACSProfile(rows=100, columns=100)
+    INDEXING = IndexingProfile()
+    VALID_BATTERIES = {
+        'unknown': ['unknown'],
     }
+    VALID_DRIVETRAIN = {
+        'control': ['diff_fwd', 'diff_rwd', 'diff_4wd', 'omni_4wd'],
+        'wheels': {
+            'front': ['outdoor', 'indoor', 'mecanum', 'tracks', 'caster'],
+            'rear': ['outdoor', 'indoor', 'mecanum', 'tracks', 'caster'],
+        },
+    }
+    DEFAULT_CAN_ADAPTERS = []
+    DEFAULT_CAN_BRIDGES = []
+    ATTACHMENT_CLASS = GENERICAttachment
+
+
+Platform.register(GenericPlatformConfig)

--- a/clearpath_config/platform/definitions/generic.py
+++ b/clearpath_config/platform/definitions/generic.py
@@ -30,7 +30,6 @@ from clearpath_config.common.types.platform import (
     PACSProfile,
     Platform,
 )
-from clearpath_config.platform.attachments.generic import GENERICAttachment
 from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
@@ -63,7 +62,7 @@ class GenericPlatformConfig(BasePlatformConfig):
     }
     DEFAULT_CAN_ADAPTERS = []
     DEFAULT_CAN_BRIDGES = []
-    ATTACHMENT_CLASS = GENERICAttachment
+    DEFAULT_ATTACHMENTS = []
 
 
 Platform.register(GenericPlatformConfig)

--- a/clearpath_config/platform/definitions/generic.py
+++ b/clearpath_config/platform/definitions/generic.py
@@ -31,6 +31,8 @@ from clearpath_config.common.types.platform import (
     Platform,
 )
 from clearpath_config.platform.attachments.generic import GENERICAttachment
+from clearpath_config.platform.battery import BatteryConfig
+from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
 
 
@@ -39,13 +41,24 @@ class GenericPlatformConfig(BasePlatformConfig):
     PACS = PACSProfile(rows=100, columns=100)
     INDEXING = IndexingProfile()
     VALID_BATTERIES = {
-        'unknown': ['unknown'],
+        BatteryConfig.UNKNOWN: [BatteryConfig.UNKNOWN],
     }
     VALID_DRIVETRAIN = {
-        'control': ['diff_fwd', 'diff_rwd', 'diff_4wd', 'omni_4wd'],
-        'wheels': {
-            'front': ['outdoor', 'indoor', 'mecanum', 'tracks', 'caster'],
-            'rear': ['outdoor', 'indoor', 'mecanum', 'tracks', 'caster'],
+        DrivetrainConfig.CONTROL: [
+            DrivetrainConfig.DIFF_FWD, DrivetrainConfig.DIFF_RWD,
+            DrivetrainConfig.DIFF_4WD, DrivetrainConfig.OMNI_4WD,
+        ],
+        DrivetrainConfig.WHEELS: {
+            DrivetrainConfig.FRONT: [
+                DrivetrainConfig.OUTDOOR, DrivetrainConfig.INDOOR,
+                DrivetrainConfig.MECANUM, DrivetrainConfig.TRACKS,
+                DrivetrainConfig.CASTER,
+            ],
+            DrivetrainConfig.REAR: [
+                DrivetrainConfig.OUTDOOR, DrivetrainConfig.INDOOR,
+                DrivetrainConfig.MECANUM, DrivetrainConfig.TRACKS,
+                DrivetrainConfig.CASTER,
+            ],
         },
     }
     DEFAULT_CAN_ADAPTERS = []

--- a/clearpath_config/platform/definitions/j100.py
+++ b/clearpath_config/platform/definitions/j100.py
@@ -30,7 +30,7 @@ from clearpath_config.common.types.platform import (
     PACSProfile,
     Platform,
 )
-from clearpath_config.platform.attachments.j100 import J100Attachment
+from clearpath_config.platform.attachments.j100 import J100Fender, J100TopPlate
 from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
@@ -54,7 +54,12 @@ class J100PlatformConfig(BasePlatformConfig):
     }
     DEFAULT_CAN_ADAPTERS = []
     DEFAULT_CAN_BRIDGES = []
-    ATTACHMENT_CLASS = J100Attachment
+    DEFAULT_ATTACHMENTS = [
+        {'name': 'front_fender', 'type': 'j100.fender'},
+        {'name': 'rear_fender', 'type': 'j100.fender', 'rpy': [0, 0, 3.1415]},
+    ]
 
 
 Platform.register(J100PlatformConfig)
+J100PlatformConfig.register_attachment(J100TopPlate)
+J100PlatformConfig.register_attachment(J100Fender)

--- a/clearpath_config/platform/definitions/j100.py
+++ b/clearpath_config/platform/definitions/j100.py
@@ -25,51 +25,34 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from typing import List
-
-from clearpath_config.common.types.accessory import Accessory
-
-from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
-
-
-class DD100TopPlate(BaseAttachment):
-    PLATFORM = 'dd100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
-    PACS = 'pacs'
-    MODELS = [PACS]
-    PARENT = 'default_mount'
-    HEIGHT = 0.1
-
-    def __init__(
-            self,
-            name: str = ATTACHMENT_MODEL,
-            model: str = PACS,
-            enabled: bool = BaseAttachment.ENABLED,
-            height: float = HEIGHT,
-            parent: str = PARENT,
-            xyz: List[float] = Accessory.XYZ,
-            rpy: List[float] = Accessory.RPY
-            ) -> None:
-        super().__init__(name, model, enabled, parent, xyz, rpy)
-        self.height = height
-
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d['height'] = self.height
-        return d
-
-    def from_dict(self, d: dict) -> None:
-        super().from_dict(d)
-        if 'height' in d:
-            self.height = d['height']
+from clearpath_config.common.types.platform import (
+    IndexingProfile,
+    PACSProfile,
+    Platform,
+)
+from clearpath_config.platform.attachments.j100 import J100Attachment
+from clearpath_config.platform.platform import BasePlatformConfig
 
 
-# DD100 Attachments
-class DD100Attachment(PlatformAttachment):
-    PLATFORM = 'dd100'
-    # Top Plates
-    TOP_PLATE = DD100TopPlate.ATTACHMENT_MODEL
-
-    TYPES = {
-        TOP_PLATE: DD100TopPlate,
+class J100PlatformConfig(BasePlatformConfig):
+    NAME = 'j100'
+    PACS = PACSProfile(rows=4, columns=2)
+    INDEXING = IndexingProfile(gps=1, imu=1)
+    VALID_BATTERIES = {
+        'HE2613': ['S1P1'],
+        'HE2411': ['S1P1'],
+        'HE2410': ['S1P1'],
     }
+    VALID_DRIVETRAIN = {
+        'control': ['diff_4wd'],
+        'wheels': {
+            'front': ['outdoor'],
+            'rear': ['outdoor'],
+        },
+    }
+    DEFAULT_CAN_ADAPTERS = []
+    DEFAULT_CAN_BRIDGES = []
+    ATTACHMENT_CLASS = J100Attachment
+
+
+Platform.register(J100PlatformConfig)

--- a/clearpath_config/platform/definitions/j100.py
+++ b/clearpath_config/platform/definitions/j100.py
@@ -56,7 +56,7 @@ class J100PlatformConfig(BasePlatformConfig):
     DEFAULT_CAN_BRIDGES = []
     DEFAULT_ATTACHMENTS = [
         {'name': 'front_fender', 'type': 'j100.fender'},
-        {'name': 'rear_fender', 'type': 'j100.fender', 'rpy': [0, 0, 3.1415]},
+        {'name': 'rear_fender', 'type': 'j100.fender', 'rpy': [0.0, 0.0, 3.1415]},
     ]
 
 

--- a/clearpath_config/platform/definitions/j100.py
+++ b/clearpath_config/platform/definitions/j100.py
@@ -31,6 +31,8 @@ from clearpath_config.common.types.platform import (
     Platform,
 )
 from clearpath_config.platform.attachments.j100 import J100Attachment
+from clearpath_config.platform.battery import BatteryConfig
+from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
 
 
@@ -39,15 +41,15 @@ class J100PlatformConfig(BasePlatformConfig):
     PACS = PACSProfile(rows=4, columns=2)
     INDEXING = IndexingProfile(gps=1, imu=1)
     VALID_BATTERIES = {
-        'HE2613': ['S1P1'],
-        'HE2411': ['S1P1'],
-        'HE2410': ['S1P1'],
+        BatteryConfig.HE2613: [BatteryConfig.S1P1],
+        BatteryConfig.HE2411: [BatteryConfig.S1P1],
+        BatteryConfig.HE2410: [BatteryConfig.S1P1],
     }
     VALID_DRIVETRAIN = {
-        'control': ['diff_4wd'],
-        'wheels': {
-            'front': ['outdoor'],
-            'rear': ['outdoor'],
+        DrivetrainConfig.CONTROL: [DrivetrainConfig.DIFF_4WD],
+        DrivetrainConfig.WHEELS: {
+            DrivetrainConfig.FRONT: [DrivetrainConfig.OUTDOOR],
+            DrivetrainConfig.REAR: [DrivetrainConfig.OUTDOOR],
         },
     }
     DEFAULT_CAN_ADAPTERS = []

--- a/clearpath_config/platform/definitions/r100.py
+++ b/clearpath_config/platform/definitions/r100.py
@@ -31,7 +31,9 @@ from clearpath_config.common.types.platform import (
     Platform,
 )
 from clearpath_config.platform.attachments.r100 import R100Attachment
+from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
+from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
 
 
@@ -40,13 +42,13 @@ class R100PlatformConfig(BasePlatformConfig):
     PACS = PACSProfile(rows=100, columns=100)
     INDEXING = IndexingProfile(imu=1)
     VALID_BATTERIES = {
-        '8A31DTM': ['S1P2'],
+        BatteryConfig.DTM8A31: [BatteryConfig.S1P2],
     }
     VALID_DRIVETRAIN = {
-        'control': ['omni_4wd', 'diff_4wd'],
-        'wheels': {
-            'front': ['mecanum'],
-            'rear': ['mecanum'],
+        DrivetrainConfig.CONTROL: [DrivetrainConfig.OMNI_4WD, DrivetrainConfig.DIFF_4WD],
+        DrivetrainConfig.WHEELS: {
+            DrivetrainConfig.FRONT: [DrivetrainConfig.MECANUM],
+            DrivetrainConfig.REAR: [DrivetrainConfig.MECANUM],
         },
     }
     DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]

--- a/clearpath_config/platform/definitions/r100.py
+++ b/clearpath_config/platform/definitions/r100.py
@@ -25,51 +25,33 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from typing import List
-
-from clearpath_config.common.types.accessory import Accessory
-
-from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
-
-
-class DD100TopPlate(BaseAttachment):
-    PLATFORM = 'dd100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
-    PACS = 'pacs'
-    MODELS = [PACS]
-    PARENT = 'default_mount'
-    HEIGHT = 0.1
-
-    def __init__(
-            self,
-            name: str = ATTACHMENT_MODEL,
-            model: str = PACS,
-            enabled: bool = BaseAttachment.ENABLED,
-            height: float = HEIGHT,
-            parent: str = PARENT,
-            xyz: List[float] = Accessory.XYZ,
-            rpy: List[float] = Accessory.RPY
-            ) -> None:
-        super().__init__(name, model, enabled, parent, xyz, rpy)
-        self.height = height
-
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d['height'] = self.height
-        return d
-
-    def from_dict(self, d: dict) -> None:
-        super().from_dict(d)
-        if 'height' in d:
-            self.height = d['height']
+from clearpath_config.common.types.platform import (
+    IndexingProfile,
+    PACSProfile,
+    Platform,
+)
+from clearpath_config.platform.attachments.r100 import R100Attachment
+from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
+from clearpath_config.platform.platform import BasePlatformConfig
 
 
-# DD100 Attachments
-class DD100Attachment(PlatformAttachment):
-    PLATFORM = 'dd100'
-    # Top Plates
-    TOP_PLATE = DD100TopPlate.ATTACHMENT_MODEL
-
-    TYPES = {
-        TOP_PLATE: DD100TopPlate,
+class R100PlatformConfig(BasePlatformConfig):
+    NAME = 'r100'
+    PACS = PACSProfile(rows=100, columns=100)
+    INDEXING = IndexingProfile(imu=1)
+    VALID_BATTERIES = {
+        '8A31DTM': ['S1P2'],
     }
+    VALID_DRIVETRAIN = {
+        'control': ['omni_4wd', 'diff_4wd'],
+        'wheels': {
+            'front': ['mecanum'],
+            'rear': ['mecanum'],
+        },
+    }
+    DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]
+    DEFAULT_CAN_BRIDGES = CANBridgeConfig.SINGLE_VCAN_DEFAULT
+    ATTACHMENT_CLASS = R100Attachment
+
+
+Platform.register(R100PlatformConfig)

--- a/clearpath_config/platform/definitions/r100.py
+++ b/clearpath_config/platform/definitions/r100.py
@@ -30,7 +30,7 @@ from clearpath_config.common.types.platform import (
     PACSProfile,
     Platform,
 )
-from clearpath_config.platform.attachments.r100 import R100Attachment
+from clearpath_config.platform.attachments.r100 import R100FAMS, R100HAMS, R100Tower
 from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.can import CANAdapterConfig, CANBridgeConfig
 from clearpath_config.platform.drivetrain import DrivetrainConfig
@@ -53,7 +53,10 @@ class R100PlatformConfig(BasePlatformConfig):
     }
     DEFAULT_CAN_ADAPTERS = [CANAdapterConfig.VCAN0_DEFAULT]
     DEFAULT_CAN_BRIDGES = CANBridgeConfig.SINGLE_VCAN_DEFAULT
-    ATTACHMENT_CLASS = R100Attachment
+    DEFAULT_ATTACHMENTS = []
 
 
 Platform.register(R100PlatformConfig)
+R100PlatformConfig.register_attachment(R100FAMS)
+R100PlatformConfig.register_attachment(R100HAMS)
+R100PlatformConfig.register_attachment(R100Tower)

--- a/clearpath_config/platform/definitions/w200.py
+++ b/clearpath_config/platform/definitions/w200.py
@@ -30,7 +30,11 @@ from clearpath_config.common.types.platform import (
     PACSProfile,
     Platform,
 )
-from clearpath_config.platform.attachments.w200 import W200Attachment
+from clearpath_config.platform.attachments.w200 import (
+    W200ArmPlate,
+    W200Bulkhead,
+    W200Generator,
+)
 from clearpath_config.platform.battery import BatteryConfig
 from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
@@ -55,7 +59,10 @@ class W200PlatformConfig(BasePlatformConfig):
     }
     DEFAULT_CAN_ADAPTERS = []
     DEFAULT_CAN_BRIDGES = []
-    ATTACHMENT_CLASS = W200Attachment
+    DEFAULT_ATTACHMENTS = []
 
 
 Platform.register(W200PlatformConfig)
+W200PlatformConfig.register_attachment(W200Generator)
+W200PlatformConfig.register_attachment(W200Bulkhead)
+W200PlatformConfig.register_attachment(W200ArmPlate)

--- a/clearpath_config/platform/definitions/w200.py
+++ b/clearpath_config/platform/definitions/w200.py
@@ -25,51 +25,35 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-from typing import List
-
-from clearpath_config.common.types.accessory import Accessory
-
-from clearpath_config.platform.types.attachment import BaseAttachment, PlatformAttachment
-
-
-class DD100TopPlate(BaseAttachment):
-    PLATFORM = 'dd100'
-    ATTACHMENT_MODEL = '%s.top_plate' % PLATFORM
-    PACS = 'pacs'
-    MODELS = [PACS]
-    PARENT = 'default_mount'
-    HEIGHT = 0.1
-
-    def __init__(
-            self,
-            name: str = ATTACHMENT_MODEL,
-            model: str = PACS,
-            enabled: bool = BaseAttachment.ENABLED,
-            height: float = HEIGHT,
-            parent: str = PARENT,
-            xyz: List[float] = Accessory.XYZ,
-            rpy: List[float] = Accessory.RPY
-            ) -> None:
-        super().__init__(name, model, enabled, parent, xyz, rpy)
-        self.height = height
-
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d['height'] = self.height
-        return d
-
-    def from_dict(self, d: dict) -> None:
-        super().from_dict(d)
-        if 'height' in d:
-            self.height = d['height']
+from clearpath_config.common.types.platform import (
+    IndexingProfile,
+    PACSProfile,
+    Platform,
+)
+from clearpath_config.platform.attachments.w200 import W200Attachment
+from clearpath_config.platform.platform import BasePlatformConfig
 
 
-# DD100 Attachments
-class DD100Attachment(PlatformAttachment):
-    PLATFORM = 'dd100'
-    # Top Plates
-    TOP_PLATE = DD100TopPlate.ATTACHMENT_MODEL
-
-    TYPES = {
-        TOP_PLATE: DD100TopPlate,
+class W200PlatformConfig(BasePlatformConfig):
+    NAME = 'w200'
+    PACS = PACSProfile(rows=100, columns=100)
+    INDEXING = IndexingProfile(imu=1)
+    VALID_BATTERIES = {
+        'U1_35': ['S4P3'],
+        'NEC_ALM12V35': ['S4P3'],
+        'VALENCE_U24_12XP': ['S4P1'],
+        'VALENCE_U27_12XP': ['S4P1'],
     }
+    VALID_DRIVETRAIN = {
+        'control': ['diff_4wd'],
+        'wheels': {
+            'front': ['outdoor', 'tracks'],
+            'rear': ['outdoor', 'tracks'],
+        },
+    }
+    DEFAULT_CAN_ADAPTERS = []
+    DEFAULT_CAN_BRIDGES = []
+    ATTACHMENT_CLASS = W200Attachment
+
+
+Platform.register(W200PlatformConfig)

--- a/clearpath_config/platform/definitions/w200.py
+++ b/clearpath_config/platform/definitions/w200.py
@@ -31,6 +31,8 @@ from clearpath_config.common.types.platform import (
     Platform,
 )
 from clearpath_config.platform.attachments.w200 import W200Attachment
+from clearpath_config.platform.battery import BatteryConfig
+from clearpath_config.platform.drivetrain import DrivetrainConfig
 from clearpath_config.platform.platform import BasePlatformConfig
 
 
@@ -39,16 +41,16 @@ class W200PlatformConfig(BasePlatformConfig):
     PACS = PACSProfile(rows=100, columns=100)
     INDEXING = IndexingProfile(imu=1)
     VALID_BATTERIES = {
-        'U1_35': ['S4P3'],
-        'NEC_ALM12V35': ['S4P3'],
-        'VALENCE_U24_12XP': ['S4P1'],
-        'VALENCE_U27_12XP': ['S4P1'],
+        BatteryConfig.U1_35: [BatteryConfig.S4P3],
+        BatteryConfig.NEC_ALM12V35: [BatteryConfig.S4P3],
+        BatteryConfig.VALENCE_U24_12XP: [BatteryConfig.S4P1],
+        BatteryConfig.VALENCE_U27_12XP: [BatteryConfig.S4P1],
     }
     VALID_DRIVETRAIN = {
-        'control': ['diff_4wd'],
-        'wheels': {
-            'front': ['outdoor', 'tracks'],
-            'rear': ['outdoor', 'tracks'],
+        DrivetrainConfig.CONTROL: [DrivetrainConfig.DIFF_4WD],
+        DrivetrainConfig.WHEELS: {
+            DrivetrainConfig.FRONT: [DrivetrainConfig.OUTDOOR, DrivetrainConfig.TRACKS],
+            DrivetrainConfig.REAR: [DrivetrainConfig.OUTDOOR, DrivetrainConfig.TRACKS],
         },
     }
     DEFAULT_CAN_ADAPTERS = []

--- a/clearpath_config/platform/drivetrain.py
+++ b/clearpath_config/platform/drivetrain.py
@@ -55,78 +55,13 @@ class DrivetrainConfig(BaseConfig):
     LAUNCH_ARGS = 'launch_args'
 
     # Valid drivetrain type and wheels given a platform
-    VALID = {
-        Platform.GENERIC: {
-            CONTROL: [DIFF_FWD, DIFF_RWD, DIFF_4WD, OMNI_4WD],
-            WHEELS: {
-                FRONT: [OUTDOOR, INDOOR, MECANUM, TRACKS, CASTER],
-                REAR:  [OUTDOOR, INDOOR, MECANUM, TRACKS, CASTER],
-            }
-        },
-        Platform.A200: {
-            CONTROL: [DIFF_4WD],
-            WHEELS: {
-                FRONT: [OUTDOOR, INDOOR],
-                REAR:  [OUTDOOR, INDOOR]
-            }
-        },
-        Platform.A300: {
-            CONTROL: [DIFF_4WD, DIFF_FWD, DIFF_RWD, OMNI_4WD],
-            WHEELS: {
-                FRONT: [OUTDOOR, CASTER, MECANUM],
-                REAR:  [OUTDOOR, CASTER, MECANUM]
-            }
-        },
-        Platform.DD100: {
-            CONTROL: [DIFF_FWD],
-            WHEELS: {
-                FRONT: [INDOOR],
-                REAR:  [CASTER]
-            }
-        },
-        Platform.DO100: {
-            CONTROL: [OMNI_4WD, DIFF_4WD],
-            WHEELS: {
-                FRONT: [MECANUM],
-                REAR:  [MECANUM]
-            }
-        },
-        Platform.DD150: {
-            CONTROL: [DIFF_FWD],
-            WHEELS: {
-                FRONT: [INDOOR],
-                REAR:  [CASTER]
-            }
-        },
-        Platform.DO150: {
-            CONTROL: [OMNI_4WD, DIFF_4WD],
-            WHEELS: {
-                FRONT: [MECANUM],
-                REAR:  [MECANUM]
-            }
-        },
-        Platform.J100: {
-            CONTROL: [DIFF_4WD],
-            WHEELS: {
-                FRONT: [OUTDOOR],
-                REAR:  [OUTDOOR]
-            }
-        },
-        Platform.R100: {
-            CONTROL: [OMNI_4WD, DIFF_4WD],
-            WHEELS: {
-                FRONT: [MECANUM],
-                REAR:  [MECANUM]
-            }
-        },
-        Platform.W200: {
-            CONTROL: [DIFF_4WD],
-            WHEELS: {
-                FRONT: [OUTDOOR, TRACKS],
-                REAR:  [OUTDOOR, TRACKS]
-            }
-        }
-    }
+    VALID = {}  # Populated dynamically from platform registry
+
+    @staticmethod
+    def _get_valid_drivetrain(platform=None):
+        if platform is None:
+            platform = BaseConfig.get_platform_model()
+        return Platform.get(platform).VALID_DRIVETRAIN
 
     # Valid wheels given a drivetrain type
     VALID_WHEELS = {
@@ -207,9 +142,10 @@ class DrivetrainConfig(BaseConfig):
 
     def update_defaults(self) -> None:
         platform = BaseConfig.get_platform_model()
-        self.DEFAULTS[self.CONTROL] = list(self.VALID[platform][self.CONTROL])[0]
-        self.DEFAULTS[self.FRONT] = list(self.VALID[platform][self.WHEELS][self.FRONT])[0]
-        self.DEFAULTS[self.REAR] = list(self.VALID[platform][self.WHEELS][self.REAR])[0]
+        valid = self._get_valid_drivetrain(platform)
+        self.DEFAULTS[self.CONTROL] = list(valid[self.CONTROL])[0]
+        self.DEFAULTS[self.FRONT] = list(valid[self.WHEELS][self.FRONT])[0]
+        self.DEFAULTS[self.REAR] = list(valid[self.WHEELS][self.REAR])[0]
 
     def update(self, serial_number: bool = False) -> None:
         if serial_number:
@@ -226,28 +162,25 @@ class DrivetrainConfig(BaseConfig):
     @control.setter
     def control(self, value: str) -> None:
         platform = BaseConfig.get_platform_model()
-        if platform not in self.VALID:
+        valid = self._get_valid_drivetrain(platform)
+        if value not in valid[self.CONTROL]:
             raise ValueError(
-                f'Platform "{platform}" is invalid. Must be one of "{list(self.VALID)}"'
-            )
-        if value not in self.VALID[platform][self.CONTROL]:
-            raise ValueError(
-                f'Drivetrain control "{value}" is invalid. Drivetrain control for platform "{platform}" must be one of "{list(self.VALID[platform][self.CONTROL])}"'  # noqa:E501
+                f'Drivetrain control "{value}" is invalid. Drivetrain control for platform "{platform}" must be one of "{list(valid[self.CONTROL])}"'  # noqa:E501
             )
         self._control = value
         # Check that front wheels are valid with updated control
         if self.front_wheels not in list(
-            set(self.VALID[platform][self.WHEELS][self.FRONT]).intersection(
+            set(valid[self.WHEELS][self.FRONT]).intersection(
                 self.VALID_WHEELS[self.control][self.FRONT])):
             self.front_wheels = list(
-                set(self.VALID[platform][self.WHEELS][self.FRONT]).intersection(
+                set(valid[self.WHEELS][self.FRONT]).intersection(
                     self.VALID_WHEELS[self.control][self.FRONT]))[0]
         # Check that rear wheels are valid with updated control
         if self.rear_wheels not in list(
-            set(self.VALID[platform][self.WHEELS][self.REAR]).intersection(
+            set(valid[self.WHEELS][self.REAR]).intersection(
                 self.VALID_WHEELS[self.control][self.REAR])):
             self.rear_wheels = list(
-                  set(self.VALID[platform][self.WHEELS][self.REAR]).intersection(
+                  set(valid[self.WHEELS][self.REAR]).intersection(
                       self.VALID_WHEELS[self.control][self.REAR]))[0]
 
     @property
@@ -260,20 +193,17 @@ class DrivetrainConfig(BaseConfig):
     @front_wheels.setter
     def front_wheels(self, value: str) -> None:
         platform = BaseConfig.get_platform_model()
-        if platform not in self.VALID:
+        valid = self._get_valid_drivetrain(platform)
+        if self.control not in valid[self.CONTROL]:
             raise ValueError(
-                f'Platform "{platform}" is invalid. Must be one of "{list(self.VALID[self.WHEELS])}"'  # noqa:E501
-            )
-        if self.control not in self.VALID[platform][self.CONTROL]:
-            raise ValueError(
-                f'Drivetrain control "{self.control}" is invalid. Drivetrain control for platform "{platform}" must be one of "{list(self.VALID[self.CONTROL][platform])}"'  # noqa: E501
+                f'Drivetrain control "{self.control}" is invalid. Drivetrain control for platform "{platform}" must be one of "{list(valid[self.CONTROL])}"'  # noqa: E501
             )
         if (
-            value not in self.VALID[platform][self.WHEELS][self.FRONT]
+            value not in valid[self.WHEELS][self.FRONT]
             or value not in self.VALID_WHEELS[self.control][self.FRONT]
         ):
             raise ValueError(
-                f'Front wheel type "{value}" is invalid. For platform "{platform}" and drivetrain "{self.control}" it must be one of "{list(set(self.VALID[platform][self.WHEELS][self.FRONT]).intersection(self.VALID_WHEELS[self.control][self.FRONT]))}"'  # noqa:E501
+                f'Front wheel type "{value}" is invalid. For platform "{platform}" and drivetrain "{self.control}" it must be one of "{list(set(valid[self.WHEELS][self.FRONT]).intersection(self.VALID_WHEELS[self.control][self.FRONT]))}"'  # noqa:E501
             )
         self._front_wheels = value
 
@@ -287,19 +217,16 @@ class DrivetrainConfig(BaseConfig):
     @rear_wheels.setter
     def rear_wheels(self, value: str) -> None:
         platform = BaseConfig.get_platform_model()
-        if platform not in self.VALID:
+        valid = self._get_valid_drivetrain(platform)
+        if self.control not in valid[self.CONTROL]:
             raise ValueError(
-                f'Platform "{platform}" is invalid. Must be one of "{list(self.VALID[self.WHEELS])}"'  # noqa: E501
-            )
-        if self.control not in self.VALID[platform][self.CONTROL]:
-            raise ValueError(
-                f'Drivetrain control "{self.control}" is invalid. Drivetrain control for platform "{platform}" must be one of "{list(self.VALID[self.CONTROL][platform])}"'  # noqa: E501
+                f'Drivetrain control "{self.control}" is invalid. Drivetrain control for platform "{platform}" must be one of "{list(valid[self.CONTROL])}"'  # noqa: E501
             )
         if (
-            value not in self.VALID[platform][self.WHEELS][self.REAR]
+            value not in valid[self.WHEELS][self.REAR]
             or value not in self.VALID_WHEELS[self.control][self.REAR]
         ):
             raise ValueError(
-                f'Rear wheel type "{value}" is invalid. For platform "{platform}" and drivetrain "{self.control}" it must be one of "{list(set(self.VALID[platform][self.WHEELS][self.REAR]).intersection(self.VALID_WHEELS[self.control][self.REAR]))}"'  # noqa:E501
+                f'Rear wheel type "{value}" is invalid. For platform "{platform}" and drivetrain "{self.control}" it must be one of "{list(set(valid[self.WHEELS][self.REAR]).intersection(self.VALID_WHEELS[self.control][self.REAR]))}"'  # noqa:E501
             )
         self._rear_wheels = value

--- a/clearpath_config/platform/extras.py
+++ b/clearpath_config/platform/extras.py
@@ -29,7 +29,6 @@ from typing import List
 
 from clearpath_config.common.types.config import BaseConfig
 from clearpath_config.common.types.package_path import PackagePath
-from clearpath_config.common.types.platform import Platform
 from clearpath_config.common.utils.dictionary import (
     flatten_dict,
     flip_dict,
@@ -149,21 +148,21 @@ class ROSParameterDefaults:
     }
 
     DEFAULTS = {
-        Platform.A200: A200,
-        Platform.A300: A300,
-        Platform.DD100: DD100,
-        Platform.DO100: DO100,
-        Platform.DD150: DD150,
-        Platform.DO150: DO150,
-        Platform.J100: J100,
-        Platform.GENERIC: GENERIC,
-        Platform.R100: R100,
-        Platform.W200: W200,
+        'a200': A200,
+        'a300': A300,
+        'dd100': DD100,
+        'do100': DO100,
+        'dd150': DD150,
+        'do150': DO150,
+        'j100': J100,
+        'generic': GENERIC,
+        'r100': R100,
+        'w200': W200,
     }
 
     def __new__(cls, platform: str) -> dict:
-        if platform not in Platform.ALL:
-            raise ValueError(f'Platform {platform} must be one of {Platform.ALL}')
+        if platform not in cls.DEFAULTS:
+            raise ValueError(f'Platform {platform} must be one of {list(cls.DEFAULTS.keys())}')
         return cls.DEFAULTS[platform]
 
 

--- a/clearpath_config/platform/platform.py
+++ b/clearpath_config/platform/platform.py
@@ -27,7 +27,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 from clearpath_config.common.types.config import BaseConfig
 from clearpath_config.common.types.package_path import PackagePath
-from clearpath_config.common.types.platform import Platform
+from clearpath_config.common.types.platform import (
+    IndexingProfile,
+    PACSProfile,
+)
 from clearpath_config.common.utils.dictionary import flip_dict
 from clearpath_config.platform.attachments.config import AttachmentsConfig
 from clearpath_config.platform.attachments.mux import AttachmentsConfigMux
@@ -84,7 +87,24 @@ class DescriptionPackagePath(PackagePath):
         self._parameters = value
 
 
-class PlatformConfig(BaseConfig):
+class BasePlatformConfig(BaseConfig):
+
+    # --- Platform-specific data (override in concrete subclasses) ---
+    NAME = 'generic'
+    PACS = PACSProfile(rows=100, columns=100)
+    INDEXING = IndexingProfile()
+    VALID_BATTERIES = {'unknown': ['unknown']}
+    VALID_DRIVETRAIN = {
+        'control': ['diff_fwd', 'diff_rwd', 'diff_4wd', 'omni_4wd'],
+        'wheels': {
+            'front': ['outdoor', 'indoor', 'mecanum', 'tracks', 'caster'],
+            'rear': ['outdoor', 'indoor', 'mecanum', 'tracks', 'caster'],
+        },
+    }
+    DEFAULT_CAN_ADAPTERS = []
+    DEFAULT_CAN_BRIDGES = []
+    ATTACHMENT_CLASS = None  # set by concrete subclass
+    DESCRIPTION_PACKAGE = 'clearpath_platform_description'
 
     PLATFORM = 'platform'
 
@@ -213,18 +233,18 @@ class PlatformConfig(BaseConfig):
 
         # Setter Template
         setters = {
-            self.KEYS[self.CONTROLLER]: PlatformConfig.controller,
-            self.KEYS[self.ATTACHMENTS]: PlatformConfig.attachments,
-            self.KEYS[self.CAN_ADAPTERS]: PlatformConfig.can_adapters,
-            self.KEYS[self.CAN_BRIDGES]: PlatformConfig.can_bridges,
-            self.KEYS[self.BATTERY]: PlatformConfig.battery,
-            self.KEYS[self.EXTRAS]: PlatformConfig.extras,
-            self.KEYS[self.DRIVETRAIN]: PlatformConfig.drivetrain,
-            self.KEYS[self.MCU]: PlatformConfig.mcu,
-            self.KEYS[self.WIRELESS]: PlatformConfig.wireless,
-            self.KEYS[self.ENABLE_EKF]: PlatformConfig.enable_ekf,
-            self.KEYS[self.ENABLE_FOXGLOVE_BRIDGE]: PlatformConfig.enable_foxglove_bridge,
-            self.KEYS[self.ENABLE_WIRELESS_WATCHER]: PlatformConfig.enable_wireless_watcher
+            self.KEYS[self.CONTROLLER]: BasePlatformConfig.controller,
+            self.KEYS[self.ATTACHMENTS]: BasePlatformConfig.attachments,
+            self.KEYS[self.CAN_ADAPTERS]: BasePlatformConfig.can_adapters,
+            self.KEYS[self.CAN_BRIDGES]: BasePlatformConfig.can_bridges,
+            self.KEYS[self.BATTERY]: BasePlatformConfig.battery,
+            self.KEYS[self.EXTRAS]: BasePlatformConfig.extras,
+            self.KEYS[self.DRIVETRAIN]: BasePlatformConfig.drivetrain,
+            self.KEYS[self.MCU]: BasePlatformConfig.mcu,
+            self.KEYS[self.WIRELESS]: BasePlatformConfig.wireless,
+            self.KEYS[self.ENABLE_EKF]: BasePlatformConfig.enable_ekf,
+            self.KEYS[self.ENABLE_FOXGLOVE_BRIDGE]: BasePlatformConfig.enable_foxglove_bridge,
+            self.KEYS[self.ENABLE_WIRELESS_WATCHER]: BasePlatformConfig.enable_wireless_watcher
         }
         super().__init__(setters, config, self.PLATFORM)
 
@@ -236,15 +256,15 @@ class PlatformConfig(BaseConfig):
             # Reload extras
             self.extras.update(serial_number=serial_number)
             # Generic Robot Launch and URDF
-            if BaseConfig.get_platform_model() == Platform.GENERIC:
+            if BaseConfig.get_platform_model() == 'generic':
                 # Add to Template
                 template = self.template
                 if self.KEYS[self.DESCRIPTION] not in template:
-                    template[self.KEYS[self.DESCRIPTION]] = PlatformConfig.description
+                    template[self.KEYS[self.DESCRIPTION]] = BasePlatformConfig.description
                 if self.KEYS[self.LAUNCH] not in template:
-                    template[self.KEYS[self.LAUNCH]] = PlatformConfig.launch
+                    template[self.KEYS[self.LAUNCH]] = BasePlatformConfig.launch
                 if self.KEYS[self.CONTROL] not in template:
-                    template[self.KEYS[self.CONTROL]] = PlatformConfig.control
+                    template[self.KEYS[self.CONTROL]] = BasePlatformConfig.control
                 self.template = template
             else:
                 template = self.template

--- a/clearpath_config/platform/platform.py
+++ b/clearpath_config/platform/platform.py
@@ -103,8 +103,49 @@ class BasePlatformConfig(BaseConfig):
     }
     DEFAULT_CAN_ADAPTERS = []
     DEFAULT_CAN_BRIDGES = []
-    ATTACHMENT_CLASS = None  # set by concrete subclass
+    _ATTACHMENT_TYPES = {}
+    DEFAULT_ATTACHMENTS = []
     DESCRIPTION_PACKAGE = 'clearpath_platform_description'
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        # Each subclass gets its own attachment registry
+        cls._ATTACHMENT_TYPES = {}
+
+    @classmethod
+    def register_attachment(cls, attachment_cls):
+        """Register an attachment type for this platform."""
+        type_key = attachment_cls.TYPE
+        attachment_cls.ATTACHMENT_MODEL = f'{cls.NAME}.{type_key}'
+        cls._ATTACHMENT_TYPES[type_key] = attachment_cls
+
+    @classmethod
+    def get_attachment_class(cls, type_key: str):
+        """Look up an attachment class by type key."""
+        if '.' in type_key:
+            prefix, bare_key = type_key.split('.', 1)
+            if prefix != cls.NAME:
+                # Cross-platform lookup
+                from clearpath_config.common.types.platform import Platform
+                foreign_cls = Platform.get(prefix)
+                return foreign_cls.get_attachment_class(bare_key)
+            type_key = bare_key
+
+        if type_key not in cls._ATTACHMENT_TYPES:
+            raise KeyError(
+                f'{cls.NAME} has no attachment "{type_key}". '
+                f'Available: {list(cls._ATTACHMENT_TYPES.keys())}'
+            )
+        return cls._ATTACHMENT_TYPES[type_key]
+
+    @classmethod
+    def is_valid_attachment(cls, type_key: str) -> bool:
+        """Return True if type_key resolves to a registered attachment."""
+        try:
+            cls.get_attachment_class(type_key)
+            return True
+        except (KeyError, Exception):
+            return False
 
     PLATFORM = 'platform'
 

--- a/clearpath_config/platform/types/attachment.py
+++ b/clearpath_config/platform/types/attachment.py
@@ -31,8 +31,7 @@ from clearpath_config.common.types.accessory import Accessory
 
 
 class BaseAttachment(Accessory):
-    PLATFORM = 'generic'
-    ATTACHMENT_MODEL = '%s.attachment' % PLATFORM
+    TYPE = 'attachment'
     ENABLED = True
     # Models
     DEFAULT = 'default'
@@ -40,7 +39,7 @@ class BaseAttachment(Accessory):
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             model: str = DEFAULT,
             enabled: bool = ENABLED,
             parent: str = ...,

--- a/clearpath_config/platform/types/attachment.py
+++ b/clearpath_config/platform/types/attachment.py
@@ -28,11 +28,10 @@
 from typing import List
 
 from clearpath_config.common.types.accessory import Accessory
-from clearpath_config.common.types.platform import Platform
 
 
 class BaseAttachment(Accessory):
-    PLATFORM = Platform.GENERIC
+    PLATFORM = 'generic'
     ATTACHMENT_MODEL = '%s.attachment' % PLATFORM
     ENABLED = True
     # Models
@@ -86,7 +85,7 @@ class BaseAttachment(Accessory):
 
 
 class PlatformAttachment(BaseAttachment):
-    PLATFORM = Platform.GENERIC
+    PLATFORM = 'generic'
     TYPES = {}
 
     @classmethod

--- a/clearpath_config/platform/types/bumper.py
+++ b/clearpath_config/platform/types/bumper.py
@@ -32,14 +32,14 @@ from clearpath_config.platform.types.attachment import BaseAttachment
 
 
 class Bumper(BaseAttachment):
-    ATTACHMENT_MODEL = 'bumper'
+    TYPE = 'bumper'
     EXTENSION = 0.0
     DEFAULT = 'default'
     MODELS = [DEFAULT]
 
     def __init__(
             self,
-            name: str = ATTACHMENT_MODEL,
+            name: str = TYPE,
             enabled: bool = BaseAttachment.ENABLED,
             model: str = DEFAULT,
             extension: float = EXTENSION,

--- a/clearpath_config/sensors/sensors.py
+++ b/clearpath_config/sensors/sensors.py
@@ -374,7 +374,7 @@ class SensorConfig(BaseConfig):
     def update(self, serial_number=False) -> None:
         if serial_number:
             platform = self.get_platform_model()
-            index = Platform.INDEX[platform]
+            index = Platform.get(platform).INDEXING
             self._camera.set_index_offset(index.camera)
             self._gps.set_index_offset(index.gps)
             self._imu.set_index_offset(index.imu)

--- a/clearpath_config/tests/test_platform.py
+++ b/clearpath_config/tests/test_platform.py
@@ -49,8 +49,8 @@ INVALID = {
 }
 
 VALID = {
-    SERIAL_NUMBER: ['cpr-%s-0001' % robot for robot in Platform.ALL] + [
-        '%s-0001' % robot for robot in Platform.ALL],
+    SERIAL_NUMBER: ['cpr-%s-0001' % robot for robot in Platform.all_names()] + [
+        '%s-0001' % robot for robot in Platform.all_names()],
     BUMPER_MODEL: Bumper.MODELS,
     BUMPER_EXTENSION:  [0, '12.3', 12.3],
 }

--- a/clearpath_config/tests/test_samples.py
+++ b/clearpath_config/tests/test_samples.py
@@ -32,7 +32,6 @@ from clearpath_config.common.types.exception import (
     UnsupportedAccessoryException,
     UnsupportedPlatformException,
 )
-from clearpath_config.common.types.platform import Platform
 from clearpath_config.tests.test_utils import assert_not_errors
 
 
@@ -78,10 +77,10 @@ class TestPlatformSamples:
             except AssertionError as ae:
                 errors.append('A200 sample failed to load: %s' % ae.args[0])
             else:
-                if cc.get_platform_model() != Platform.A200:
+                if cc.get_platform_model() != 'a200':
                     errors.append('Platform model does not match. %s =/= %s' % (
                         cc.get_platform_model(),
-                        Platform.A200
+                        'a200'
                     ))
         assert_not_errors(errors)
 
@@ -99,9 +98,9 @@ class TestPlatformSamples:
             except AssertionError as ae:
                 errors.append('J100 sample failed to load: %s' % ae.args[0])
             else:
-                if cc.get_platform_model() != Platform.J100:
+                if cc.get_platform_model() != 'j100':
                     errors.append('Platform model does not match. %s =/= %s' % (
                         cc.get_model(),
-                        Platform.J100
+                        'j100'
                     ))
         assert_not_errors(errors)

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         package_name + '.mounts.types',
         package_name + '.platform',
         package_name + '.platform.attachments',
+        package_name + '.platform.definitions',
         package_name + '.platform.types',
         package_name + '.sensors',
         package_name + '.sensors.types',


### PR DESCRIPTION
## 1. Introduction of Registeries
This change is setting the stage for future updates, and currently does not affect the way that the `clearpath_config` is deployed or runs. However, it essentially restructures the way that entities in the configuration are found by the configuration system. Previously, the configuration system needed to know all of the possible platform configurations at initialization. Now, these platforms are instead registered as they are declared. This currently occurs in the `__init__.py` but in the future could occur at any point. 

## 2. Platform Class
The biggest change as part of this milestone. The `PlatformConfig` (that handles all configurations under the `platform:` key) has been redefined as a base class, `BasePlatformConfig`. 

Each platform will have its own subclass of inheriting from this base type. These sub-classes define the default configurations (default battery, default drive-trian, default can adapters/bridges) and constraints (e.g. valid batteries, valid drive-trains, etc.). This way all of each platform specific configurations are not determined based on several look-up tables using the old enums. 

## 3. Platform Attachments
After reorganizing the Platform configurations, the Platform attachments (such as bumpers, top plates, fenders, etc.) felt out of place. So, these were also refactored into a register based system. 

Each `BasePlatformConfig` sub-class registers all attachments. To maintain backward compatibility, users can use the platform code prefix to add an attachment to platform from another platform. For example, a user can set the `a200.top_plate` when configuring an A300 to obtain some of the larger top plates that were designed for the A200. 

The `BasePlatformConfig` also allows us to now easily define the default attachments for each platform. Therefore, now if the `attachments:` key is not present or set to `None`, the default attachments for that platform are loaded. If the `attachments: ` key is set to an empty string `[]`, no attachments are added. 

Next steps: all components of the robot should use a register based system to allow for dynamically extending the number of components (e.g. adding a new sensor without modifying the `clearpath_config`). 

Related PRs:
https://github.com/clearpathrobotics/clearpath_common/pull/337
https://github.com/clearpathrobotics/clearpath_robot/pull/332
https://github.com/clearpathrobotics/clearpath_simulator/pull/112