### PR TITLE
Feature: Battery State Estimator Update

### DIFF
--- a/clearpath_config/platform/battery.py
+++ b/clearpath_config/platform/battery.py
@@ -154,7 +154,7 @@ class BatteryConfig(BaseConfig):
         }
         super().__init__(setters, config, self.BATTERY)
 
-        self._validate_consistency()
+        self._validate()
 
     def update_defaults(self) -> None:
         platform = BaseConfig.get_platform_model()
@@ -271,7 +271,7 @@ class BatteryConfig(BaseConfig):
             raise TypeError(f'Battery ros_parameters {value!r} must be of type "dict"')
         self._ros_parameters = value
 
-    def _validate_consistency(self) -> None:
+    def _validate(self) -> None:
         """
         Enforce that param_file is set if and only if model == CUSTOM.
 

--- a/clearpath_config/platform/battery.py
+++ b/clearpath_config/platform/battery.py
@@ -272,7 +272,8 @@ class BatteryConfig(BaseConfig):
         self._ros_parameters = value
 
     def _validate_consistency(self) -> None:
-        """Enforce that param_file is set if and only if model == CUSTOM.
+        """
+        Enforce that param_file is set if and only if model == CUSTOM.
 
         PackagePath itself accepts either a (package, relative path) pair or
         an absolute path with no package; only the existence of a path entry

--- a/clearpath_config/platform/battery.py
+++ b/clearpath_config/platform/battery.py
@@ -26,6 +26,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 from clearpath_config.common.types.config import BaseConfig
+from clearpath_config.common.types.package_path import PackagePath
 from clearpath_config.common.types.platform import Platform
 from clearpath_config.common.utils.dictionary import flip_dict
 
@@ -36,6 +37,9 @@ class BatteryConfig(BaseConfig):
     # Models
     MODEL = 'model'
     UNKNOWN = 'unknown'
+    # User-defined battery: bypasses VALID_BATTERIES validation and requires
+    # PARAM_FILE to point at a user-supplied parameter YAML.
+    CUSTOM = 'custom'
     # D100 Lead Acid
     TLV1222 = 'TLV1222'
     # D100 LiION
@@ -62,6 +66,13 @@ class BatteryConfig(BaseConfig):
     # Configurations
     CONFIGURATION = 'configuration'
     LAUNCH_ARGS = 'launch_args'
+    # External user-supplied parameter YAML (clearpath_config PackagePath).
+    # Only valid when MODEL == CUSTOM.
+    PARAM_FILE = 'param_file'
+    # Inline node parameter overrides, namespaced by node name.
+    # The battery_state_estimator block is forwarded to the node as-is.
+    ROS_PARAMETERS = 'ros_parameters'
+    BATTERY_STATE_ESTIMATOR = 'battery_state_estimator'
     S1P1 = 'S1P1'
     S1P2 = 'S1P2'
     S1P3 = 'S1P3'
@@ -83,7 +94,9 @@ class BatteryConfig(BaseConfig):
         BATTERY: {
             MODEL: MODEL,
             CONFIGURATION: CONFIGURATION,
-            LAUNCH_ARGS: LAUNCH_ARGS
+            LAUNCH_ARGS: LAUNCH_ARGS,
+            PARAM_FILE: PARAM_FILE,
+            ROS_PARAMETERS: ROS_PARAMETERS,
         }
     }
 
@@ -92,7 +105,9 @@ class BatteryConfig(BaseConfig):
     DEFAULTS = {
         MODEL: UNKNOWN,
         CONFIGURATION: UNKNOWN,
-        LAUNCH_ARGS: {}
+        LAUNCH_ARGS: {},
+        PARAM_FILE: {},
+        ROS_PARAMETERS: {},
     }
 
     def __init__(
@@ -100,7 +115,9 @@ class BatteryConfig(BaseConfig):
             config: dict = {},
             model: str = DEFAULTS[MODEL],
             configuration: str = DEFAULTS[CONFIGURATION],
-            launch_args: dict = DEFAULTS[LAUNCH_ARGS]
+            launch_args: dict = DEFAULTS[LAUNCH_ARGS],
+            param_file: dict = DEFAULTS[PARAM_FILE],
+            ros_parameters: dict = DEFAULTS[ROS_PARAMETERS],
             ) -> None:
         # Initialization
         self._config = {}
@@ -118,14 +135,26 @@ class BatteryConfig(BaseConfig):
             self.launch_args = self.DEFAULTS[self.LAUNCH_ARGS]
         else:
             self.launch_args = launch_args
+        if param_file == self.DEFAULTS[self.PARAM_FILE] or not param_file:
+            self.param_file = self.DEFAULTS[self.PARAM_FILE]
+        else:
+            self.param_file = param_file
+        if ros_parameters == self.DEFAULTS[self.ROS_PARAMETERS] or not ros_parameters:
+            self.ros_parameters = self.DEFAULTS[self.ROS_PARAMETERS]
+        else:
+            self.ros_parameters = ros_parameters
 
         # Setter Template
         setters = {
             self.KEYS[self.MODEL]: BatteryConfig.model,
             self.KEYS[self.CONFIGURATION]: BatteryConfig.configuration,
             self.KEYS[self.LAUNCH_ARGS]: BatteryConfig.launch_args,
+            self.KEYS[self.PARAM_FILE]: BatteryConfig.param_file,
+            self.KEYS[self.ROS_PARAMETERS]: BatteryConfig.ros_parameters,
         }
         super().__init__(setters, config, self.BATTERY)
+
+        self._validate_consistency()
 
     def update_defaults(self) -> None:
         platform = BaseConfig.get_platform_model()
@@ -150,11 +179,15 @@ class BatteryConfig(BaseConfig):
 
     @model.setter
     def model(self, value: str) -> None:
+        # User-defined batteries bypass the per-platform VALID_BATTERIES table.
+        if value == self.CUSTOM:
+            self._model = value
+            return
         platform = BaseConfig.get_platform_model()
         valid = self._get_valid_batteries(platform)
         if value not in valid:
             raise ValueError(
-                f'Battery model "{value}" is invalid. Battery model for platform "{platform}" must be one of "{list(valid)}"'  # noqa:E501
+                f'Battery model "{value}" is invalid. Battery model for platform "{platform}" must be one of "{list(valid) + [self.CUSTOM]}"'  # noqa:E501
             )
         self._model = value
 
@@ -168,6 +201,12 @@ class BatteryConfig(BaseConfig):
 
     @configuration.setter
     def configuration(self, value: str) -> None:
+        # User-defined batteries do not require a configuration; the
+        # configuration is supplied by the user's parameter file (and may be
+        # overridden via ros_parameters).
+        if self.model == self.CUSTOM:
+            self._configuration = value
+            return
         platform = BaseConfig.get_platform_model()
         valid = self._get_valid_batteries(platform)
         if self.model not in valid:
@@ -193,3 +232,61 @@ class BatteryConfig(BaseConfig):
         if not isinstance(value, dict):
             raise TypeError(f'Battery Launch args {value} must be of type "dict"')
         self._launch_args = value
+
+    @property
+    def param_file(self) -> dict:
+        self.set_config_param(
+            key=self.KEYS[self.PARAM_FILE],
+            value=self._param_file.to_dict()
+        )
+        return self._param_file.to_dict()
+
+    @param_file.setter
+    def param_file(self, value) -> None:
+        if value is None or value == {}:
+            self._param_file = PackagePath()
+            return
+        if isinstance(value, PackagePath):
+            self._param_file = value
+            return
+        if not isinstance(value, dict):
+            raise TypeError(
+                f'Battery param_file {value!r} must be a dict with keys '
+                f'"{PackagePath.PACKAGE}" and "{PackagePath.PATH}"'
+            )
+        self._param_file = PackagePath()
+        self._param_file.from_dict(value)
+
+    @property
+    def ros_parameters(self) -> dict:
+        self.set_config_param(
+            key=self.KEYS[self.ROS_PARAMETERS],
+            value=self._ros_parameters
+        )
+        return self._ros_parameters
+
+    @ros_parameters.setter
+    def ros_parameters(self, value: dict) -> None:
+        if not isinstance(value, dict):
+            raise TypeError(f'Battery ros_parameters {value!r} must be of type "dict"')
+        self._ros_parameters = value
+
+    def _validate_consistency(self) -> None:
+        """Enforce that param_file is set if and only if model == CUSTOM.
+
+        PackagePath itself accepts either a (package, relative path) pair or
+        an absolute path with no package; only the existence of a path entry
+        is required here.
+        """
+        has_param_file = bool(self._param_file.package) or bool(self._param_file.path)
+        if self._model == self.CUSTOM:
+            if not has_param_file:
+                raise ValueError(
+                    f'Battery model "{self.CUSTOM}" requires "{self.PARAM_FILE}" to be set'
+                )
+        else:
+            if has_param_file:
+                raise ValueError(
+                    f'Battery "{self.PARAM_FILE}" is only valid when model is "{self.CUSTOM}"; '
+                    f'got model "{self._model}"'
+                )


### PR DESCRIPTION
# Battery State Estimator Update
## 1. Parameter File Battery State Configuration
Each battery type is defined by node parameters. The single battery setup for current standard models are defined under the [`config/battery_state_estimator`](https://github.com/clearpathrobotics/clearpath_robot/tree/feature/battery_state_estimator/clearpath_hardware_interfaces/config/battery_state_estimator) directory of the `clearpath_hardware_interfaces` package. These parameters hold the following information, see the DTM8A31 SLA battery as an example:
```yaml
# DTM8A31 (24 V Sealed Lead-Acid)
/**:
  ros__parameters:
    technology: 'vrla' # Battery technology
    cell:
      voltage: 24.0    # Nominal voltage per battery unit in V
      capacity: 50.0   # Capacity per battery unit in Ah
      num_series: 1  # Number of batteries in series
      num_parallel: 1 # Number of batteries in parallel
    lookup_table: # Mapping from single battery voltages to state of charge 
      voltages:    [23.20, 23.40, 23.80, 24.00, 24.40, 24.60, 24.80, 25.00, 25.10, 25.20, 25.30, 25.40]
      percentages: [ 0.00,  0.10,  0.20,  0.30,  0.40,  0.50,  0.60,  0.70,  0.80,  0.90,  0.95,  1.00]
```

## 2. Defining a Custom Battery through the `robot.yaml`
By setting the battery model as `custom`, the `param_file` key is now read by the `clearpath_config` to inject a battery state configuration:
```yaml
platform:
  battery:
    model: custom
    param_file:
      package: my_robot_bringup
      path: config/my_custom_pack.yaml
```

When the battery model is not set to `custom`, the `num_series` and `num_parallel` are set by the `clearpath_generator_robot` based on the `robot.yaml` configuration (to maintain backwards compatibilty). 

When it is set to `custom`, these parameters are not overwritten. 

Furthermore, the `rolling_average_window` can be modified through the `robot.yaml` by using the `ros_parameters` key:
```yaml
platform:
  battery:
    model: HE2613
    ros_parameters:
      battery_state_estimator:
        rolling_average_window: 10
```
> Note: this parameter was not exposed before. By default `rolling_average_window` is set to `30` (e.g. 30 `Power` messages, published by the MCU, are kept and averaged to get stable readings. 

## 3.  Testing Pains
In order to test these changes maintained the same behaviour, I needed to produce tests per platform per model. That is because each platform produces the `Power` message slightly differently. Each platform produces slightly different data, but ultimately only the specific voltages and currents are actually used. Therefore, if we had a proper `ros2_control/HardwareInterface` per platform, we could perform the averaging at that layer and only expose the necessary information for the `BatteryStateBroadcaster` to produce a `BatteryState` message. 

In the future, once Proton is HAL/HardwareInterface compatible, this node will no longer be required and will just need to be mapped to that system. With that updated architecture, a mock `ClearpathPlatformHardwareInterface` will provide all the data required to test controllers such as the `BatteryStateBroadcaster` and, a not yet implemented, `PlatformLightController`. 

Related PRs:
- clearpath_robot: https://github.com/clearpathrobotics/clearpath_robot/pull/335
- clearpath_generator_tests: https://github.com/clearpathrobotics/clearpath_generator_tests/pull/10